### PR TITLE
NOT READY : Add CLI documentation for iron_cli

### DIFF
--- a/module/iron_cli/docs/cli/dictionary.md
+++ b/module/iron_cli/docs/cli/dictionary.md
@@ -1,0 +1,34 @@
+# Dictionary
+
+| Term | Definition |
+|------|------------|
+| **access token** | Short-lived JWT token used for API authentication |
+| **agent** | Autonomous entity that consumes API tokens and interacts with providers |
+| **agent ID** | Unique UUID identifier for an agent |
+| **inference provider** | LLM service (OpenAI, Anthropic, Gemini, xAI) that processes AI requests |
+| **IP token** | Inference Provider token - credential for LLM provider authentication (e.g., OpenAI sk-xxx) |
+| **API token** | Long-lived token for programmatic API access |
+| **budget** | Spending limit assigned to an agent in microdollars |
+| **control API** | Management plane for agents, providers, users, and analytics |
+| **dry run** | Preview mode that shows what would happen without executing |
+| **IC token** | Iron Cage token for agent authentication |
+| **idempotent** | Operation that produces same result regardless of repetition |
+| **JWT** | JSON Web Token used for authentication |
+| **keyring** | System secure storage for credentials (OS keychain) |
+| **limit** | Usage constraint (tokens, requests, or cost per time window) |
+| **limit ID** | Numeric identifier for a usage limit |
+| **microdollar** | One millionth of a dollar (1,000,000 microdollars = $1.00) |
+| **pagination** | Splitting large result sets into pages |
+| **provider** | Short for inference provider - LLM service (openai, anthropic, gemini, xai) |
+| **provider ID** | Unique identifier for a configured provider |
+| **refresh token** | Long-lived token used to obtain new access tokens |
+| **scope** | Permission level for API tokens (e.g., read:tokens) |
+| **stdin** | Standard input, data piped from another command |
+| **stdout** | Standard output, data sent to terminal or piped |
+| **token** | API token for authenticating requests to Iron |
+| **token ID** | Unique identifier for an API token (format: tok_xxx) |
+| **trace** | Record of an API call with timing and usage data |
+| **trace ID** | Numeric identifier for a trace record |
+| **TTL** | Time-to-live, duration until expiration in seconds |
+| **usage** | Consumption metrics (tokens, requests, cost) |
+| **verbosity** | Output detail level (0=silent, 1=normal, 2=verbose, 3=debug, 4=trace, 5=all) |

--- a/module/iron_cli/docs/cli/entities/agent.md
+++ b/module/iron_cli/docs/cli/entities/agent.md
@@ -1,0 +1,246 @@
+# .agent
+
+## .agent.list
+
+List all agents.
+
+```bash
+iron .agent.list
+iron .agent.list format::json v::2
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `v::` | integer (0-5) | Verbosity level | 1 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+| `page::` | integer | Page number | 1 |
+| `limit::` | integer | Results per page | 20 |
+
+**Response**: Array of [agent_response](../parameter_types.md#agent_response)
+
+**Example**:
+```bash
+iron .agent.list
+# ┌──────────────┬────────────┬───────────┬──────────┬────────┐
+# │ ID           │ Name       │ Providers │ Budget   │ Status │
+# ├──────────────┼────────────┼───────────┼──────────┼────────┤
+# │ abc123       │ my-agent   │ openai    │ $1.00    │ active │
+# │ def456       │ prod-agent │ anthropic │ $10.00   │ active │
+# └──────────────┴────────────┴───────────┴──────────┴────────┘
+
+iron .agent.list format::json
+```
+
+---
+
+## .agent.create
+
+Create new agent.
+
+```bash
+iron .agent.create name::<name> providers::<list> provider_key_id::<id> budget::<amount>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `name::` | string | Agent name (3-100 chars) | - |
+| `providers::` | string | Comma-separated provider list | - |
+| `provider_key_id::` | integer | Provider key ID | - |
+| `budget::` | integer | Initial budget in microdollars | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Created [agent_response](../parameter_types.md#agent_response)
+
+**Example**:
+```bash
+iron .agent.create name::my-agent providers::openai provider_key_id::1 budget::1000000
+# Agent created
+# ID: abc123
+# Name: my-agent
+# Providers: openai
+# Budget: $1.00
+
+# dry run
+iron .agent.create name::test-agent providers::openai provider_key_id::1 budget::500000 dry::1
+# Would create agent: test-agent (dry run)
+```
+
+---
+
+## .agent.get
+
+Get agent details by ID.
+
+```bash
+iron .agent.get id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID (UUID) | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [agent_response](../parameter_types.md#agent_response) with complete configuration
+
+**Example**:
+```bash
+iron .agent.get id::abc123
+# Agent: abc123
+# ───────────────────────────────
+# Name: my-agent
+# Providers: openai
+# Status: active
+#
+# Budget
+# ┌────────────┬───────────┐
+# │ Field      │ Value     │
+# ├────────────┼───────────┤
+# │ Total      │ $1.00     │
+# │ Used       │ $0.25     │
+# │ Remaining  │ $0.75     │
+# └────────────┴───────────┘
+#
+# Created: 2024-01-15T10:30:00Z
+# Updated: 2024-01-15T14:00:00Z
+```
+
+---
+
+## .agent.update
+
+Update agent.
+
+```bash
+iron .agent.update id::<id> name::<name>
+iron .agent.update id::<id> budget::<amount>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID | - |
+| `name::` | string | New agent name | - |
+| `budget::` | integer | New budget in microdollars | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated [agent_response](../parameter_types.md#agent_response)
+
+**Example**:
+```bash
+iron .agent.update id::abc123 name::renamed-agent
+# Agent updated: abc123
+# Name: renamed-agent
+
+iron .agent.update id::abc123 budget::2000000
+# Agent updated: abc123
+# Budget: $2.00
+```
+
+---
+
+## .agent.delete
+
+Delete agent.
+
+```bash
+iron .agent.delete id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [success_response](../parameter_types.md#success_response)
+
+**Example**:
+```bash
+iron .agent.delete id::abc123
+# Agent deleted: abc123
+
+iron .agent.delete id::abc123 dry::1
+# Would delete agent: abc123 (dry run)
+```
+
+---
+
+## .agent.assign_providers
+
+Assign providers to agent.
+
+```bash
+iron .agent.assign_providers id::<id> provider_ids::<list>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID | - |
+| `provider_ids::` | string | Comma-separated provider IDs | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated agent with assigned providers
+
+**Example**:
+```bash
+iron .agent.assign_providers id::abc123 provider_ids::prov1,prov2
+# Providers assigned to agent: abc123
+# Providers: prov1, prov2
+```
+
+---
+
+## .agent.list_providers
+
+List agent's providers.
+
+```bash
+iron .agent.list_providers id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of assigned provider objects
+
+**Example**:
+```bash
+iron .agent.list_providers id::abc123
+# ┌──────────┬──────────┬─────────────────┐
+# │ ID       │ Provider │ Endpoint        │
+# ├──────────┼──────────┼─────────────────┤
+# │ prov1    │ openai   │ api.openai.com  │
+# │ prov2    │ anthropic│ api.anthropic.com│
+# └──────────┴──────────┴─────────────────┘
+```
+
+---
+
+## .agent.remove_provider
+
+Remove provider from agent.
+
+```bash
+iron .agent.remove_provider id::<id> provider_id::<provider_id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [agent_id](../parameter_types.md#agent_id) | Agent ID | - |
+| `provider_id::` | string | Provider ID to remove | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated agent with provider removed
+
+**Example**:
+```bash
+iron .agent.remove_provider id::abc123 provider_id::prov2
+# Provider removed from agent: abc123
+# Removed: prov2
+```
+

--- a/module/iron_cli/docs/cli/entities/analytics.md
+++ b/module/iron_cli/docs/cli/entities/analytics.md
@@ -1,0 +1,167 @@
+# .analytics
+
+Unified command for usage metrics, spending, and request traces.
+
+```bash
+iron .analytics
+iron .analytics type::<type>
+iron .analytics group_by::<dimension>
+iron .analytics agent_id::<id> provider_id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `type::` | enum | Data type: `metrics`, `usage`, `spending`, `traces` | `metrics` |
+| `id::` | integer | Get specific trace by ID (when type::traces) | - |
+| `group_by::` | enum | Group results: `agent`, `provider`, `period` | - |
+| `agent_id::` | string | Filter by agent ID | - |
+| `provider_id::` | string | Filter by provider ID | - |
+| `project_id::` | string | Filter by project ID | - |
+| `period::` | enum | Time period: `day`, `week`, `month` | - |
+| `limit::` | integer | Max results (for traces) | 20 |
+| `export::` | string | Export to file path | - |
+| `export_format::` | enum | Export format: `json`, `csv`, `yaml` | `json` |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+---
+
+## Metrics (default)
+
+Combined usage and spending statistics.
+
+```bash
+# all metrics
+iron .analytics
+# Analytics
+# ───────────────────────────────
+# Total Tokens: 5,000,000
+# Total Requests: 1,200
+# Total Cost: $50.00
+
+# only usage
+iron .analytics type::usage
+
+# only spending
+iron .analytics type::spending
+```
+
+---
+
+## Grouping
+
+Group results by dimension.
+
+```bash
+# by agent
+iron .analytics group_by::agent
+# ┌────────────┬──────────┬──────────┬────────┐
+# │ Agent      │ Tokens   │ Requests │ Cost   │
+# ├────────────┼──────────┼──────────┼────────┤
+# │ my-agent   │ 3,000,000│ 800      │ $30.00 │
+# │ prod-agent │ 2,000,000│ 400      │ $20.00 │
+# └────────────┴──────────┴──────────┴────────┘
+
+# by provider
+iron .analytics group_by::provider
+# ┌───────────┬──────────┬──────────┬────────┐
+# │ Provider  │ Tokens   │ Requests │ Cost   │
+# ├───────────┼──────────┼──────────┼────────┤
+# │ openai    │ 4,000,000│ 1,000    │ $40.00 │
+# │ anthropic │ 1,000,000│ 200      │ $10.00 │
+# └───────────┴──────────┴──────────┴────────┘
+
+# by period
+iron .analytics group_by::period period::month
+# ┌────────────┬──────────┬────────┐
+# │ Period     │ Tokens   │ Cost   │
+# ├────────────┼──────────┼────────┤
+# │ 2024-01    │ 3,500,000│ $35.00 │
+# │ 2023-12    │ 1,500,000│ $15.00 │
+# └────────────┴──────────┴────────┘
+```
+
+---
+
+## Filtering
+
+Filter by agent, provider, project, or combine filters.
+
+```bash
+# specific agent
+iron .analytics agent_id::my-agent
+
+# specific provider
+iron .analytics provider_id::openai
+
+# specific project
+iron .analytics project_id::prod
+
+# combine: agent + provider
+iron .analytics agent_id::my-agent provider_id::openai
+
+# combine: agent + provider + period
+iron .analytics agent_id::my-agent provider_id::openai period::week
+
+# group + filter: agents using openai
+iron .analytics group_by::agent provider_id::openai
+```
+
+---
+
+## Traces
+
+Request logs showing individual API calls.
+
+```bash
+# list recent traces
+iron .analytics type::traces
+# ┌─────┬─────────────┬───────────┬─────────────────┬────────┬────────┐
+# │ ID  │ Token       │ Provider  │ Model           │ Tokens │ Cost   │
+# ├─────┼─────────────┼───────────┼─────────────────┼────────┼────────┤
+# │ 999 │ tok_abc123  │ openai    │ gpt-4           │ 1,500  │ $0.045 │
+# │ 998 │ tok_abc123  │ openai    │ gpt-3.5-turbo   │ 800    │ $0.002 │
+# │ 997 │ tok_def456  │ anthropic │ claude-3-sonnet │ 2,000  │ $0.030 │
+# └─────┴─────────────┴───────────┴─────────────────┴────────┴────────┘
+
+# more traces
+iron .analytics type::traces limit::50
+
+# specific trace
+iron .analytics type::traces id::999
+# Trace ID: 999
+# ───────────────────────────────
+# Token: tok_abc123
+# Provider: openai
+# Model: gpt-4
+# Timestamp: 2024-01-15T14:22:00Z
+# Prompt tokens: 500
+# Completion tokens: 1,000
+# Total tokens: 1,500
+# Cost: $0.045
+
+# filter traces by agent
+iron .analytics type::traces agent_id::my-agent
+
+# filter traces by provider
+iron .analytics type::traces provider_id::openai
+```
+
+---
+
+## Export
+
+Export data to file.
+
+```bash
+# export metrics
+iron .analytics export::report.json
+
+# export as CSV
+iron .analytics export::report.csv export_format::csv
+
+# export with filters
+iron .analytics agent_id::my-agent export::agent-report.csv export_format::csv
+
+# export traces
+iron .analytics type::traces export::traces.json
+```

--- a/module/iron_cli/docs/cli/entities/auth.md
+++ b/module/iron_cli/docs/cli/entities/auth.md
@@ -1,0 +1,94 @@
+# .auth
+
+## .auth.login
+
+Authenticate user and obtain JWT tokens.
+
+```bash
+iron .auth.login email::<email> password::<password>
+iron .auth.login username::<username> password::<password>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `email::` | [email](../parameter_types.md#email) | Email for authentication | - |
+| `username::` | string | Username (Control API) | - |
+| `password::` | string (sensitive) | User password | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: JWT tokens stored in system keyring
+
+**Example**:
+```bash
+# login with email (Token API)
+iron .auth.login email::user@example.com password::secret
+# Authentication successful
+# Access token expires: 2024-01-15T11:30:00Z
+
+# login with username (Control API)
+iron .auth.login username::admin password::secret
+
+# interactive password prompt
+iron .auth.login email::user@example.com
+# Password: [hidden input]
+
+# JSON output
+iron .auth.login email::user@example.com password::secret format::json
+# {
+#   "access_token_expires": "2024-01-15T11:30:00Z",
+#   "message": "Authentication successful"
+# }
+```
+
+---
+
+## .auth.refresh
+
+Refresh access token using stored refresh token.
+
+```bash
+iron .auth.refresh
+iron .auth.refresh format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated tokens in keyring
+
+**Example**:
+```bash
+iron .auth.refresh
+# Access token refreshed
+# New expiry: 2024-01-15T12:30:00Z
+
+iron .auth.refresh format::json
+# {
+#   "access_token_expires": "2024-01-15T12:30:00Z",
+#   "message": "Token refreshed successfully"
+# }
+```
+
+---
+
+## .auth.logout
+
+Invalidate tokens and clear keyring storage.
+
+```bash
+iron .auth.logout
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [success_response](../parameter_types.md#success_response)
+
+**Example**:
+```bash
+iron .auth.logout
+# Logged out successfully
+# Credentials cleared from keyring
+```

--- a/module/iron_cli/docs/cli/entities/budget.md
+++ b/module/iron_cli/docs/cli/entities/budget.md
@@ -1,0 +1,114 @@
+# .budget
+
+## .budget.status
+
+Get budget status across agents.
+
+```bash
+iron .budget.status
+iron .budget.status threshold::80
+iron .budget.status status::active
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `agent_id::` | integer | Filter by specific agent | - |
+| `threshold::` | integer | Filter agents above % used | - |
+| `status::` | string | Filter by status (active\|exhausted) | - |
+| `page::` | integer | Page number | 1 |
+| `per_page::` | integer | Results per page | 10 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Budget status array with usage, remaining amounts, risk levels
+
+**Example**:
+```bash
+iron .budget.status
+# ┌────────────┬──────────┬──────────┬───────────┬────────┬──────────┐
+# │ Agent      │ Budget   │ Used     │ Remaining │ Usage  │ Risk     │
+# ├────────────┼──────────┼──────────┼───────────┼────────┼──────────┤
+# │ my-agent   │ $1.00    │ $0.85    │ $0.15     │ 85%    │ high     │
+# │ prod-agent │ $10.00   │ $2.50    │ $7.50     │ 25%    │ low      │
+# │ test-agent │ $0.50    │ $0.50    │ $0.00     │ 100%   │ exhausted│
+# └────────────┴──────────┴──────────┴───────────┴────────┴──────────┘
+
+# filter by threshold (agents above 80% usage)
+iron .budget.status threshold::80
+# Shows only: my-agent, test-agent
+
+# filter by status
+iron .budget.status status::exhausted
+# Shows only: test-agent
+
+iron .budget.status format::json
+# [
+#   {"agent": "my-agent", "budget": 1000000, "used": 850000, "remaining": 150000, "usage_pct": 85, "risk": "high"},
+#   ...
+# ]
+```
+
+---
+
+# .budget_limit
+
+## .budget_limit.get
+
+Get global budget limit.
+
+```bash
+iron .budget_limit.get
+iron .budget_limit.get format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Global budget limit object
+
+**Example**:
+```bash
+iron .budget_limit.get
+# Global Budget Limit
+# ───────────────────────────────
+# Limit: $100.00
+# Used: $52.50
+# Remaining: $47.50
+# Usage: 52.5%
+
+iron .budget_limit.get format::json
+# {
+#   "limit": 100000000,
+#   "used": 52500000,
+#   "remaining": 47500000,
+#   "usage_pct": 52.5
+# }
+```
+
+---
+
+## .budget_limit.set
+
+Set global budget limit.
+
+```bash
+iron .budget_limit.set limit::<amount>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `limit::` | integer | New budget limit in microdollars | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated budget limit object
+
+**Example**:
+```bash
+iron .budget_limit.set limit::200000000
+# Global budget limit updated
+# New limit: $200.00
+
+iron .budget_limit.set limit::150000000 dry::1
+# Would set global budget limit to: $150.00 (dry run)
+```

--- a/module/iron_cli/docs/cli/entities/limits.md
+++ b/module/iron_cli/docs/cli/entities/limits.md
@@ -1,0 +1,187 @@
+# .limits
+
+## .limits.list
+
+List all configured limits.
+
+```bash
+iron .limits.list
+iron .limits.list format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of [limit_response](../parameter_types.md#limit_response)
+
+**Example**:
+```bash
+iron .limits.list
+# ┌────┬──────────────┬───────────┬─────────────┬─────────┐
+# │ ID │ Type         │ Max Value │ Time Window │ Current │
+# ├────┼──────────────┼───────────┼─────────────┼─────────┤
+# │ 1  │ tokens/day   │ 1,000,000 │ day         │ 250,000 │
+# │ 2  │ requests/min │ 100       │ minute      │ 15      │
+# │ 3  │ cost/month   │ 10000     │ month       │ 1550    │
+# └────┴──────────────┴───────────┴─────────────┴─────────┘
+
+iron .limits.list format::json
+# [
+#   {"id": 1, "type": "tokens/day", "max_value": 1000000, "time_window": "day", "current_value": 250000},
+#   {"id": 2, "type": "requests/min", "max_value": 100, "time_window": "minute", "current_value": 15},
+#   {"id": 3, "type": "cost/month", "max_value": 10000, "time_window": "month", "current_value": 1550}
+# ]
+```
+
+---
+
+## .limits.get
+
+Get specific limit details by ID.
+
+```bash
+iron .limits.get limit_id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `limit_id::` | [limit_id](../parameter_types.md#limit_id) | Numeric limit identifier | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [limit_response](../parameter_types.md#limit_response)
+
+**Example**:
+```bash
+iron .limits.get limit_id::1
+# Limit ID: 1
+# Type: tokens/day
+# Max Value: 1,000,000
+# Time Window: day
+# Current Value: 250,000
+# Usage: 25%
+# Resets: 2024-01-16T00:00:00Z
+
+iron .limits.get limit_id::1 format::json
+# {
+#   "id": 1,
+#   "type": "tokens/day",
+#   "max_value": 1000000,
+#   "time_window": "day",
+#   "current_value": 250000,
+#   "reset_at": "2024-01-16T00:00:00Z"
+# }
+```
+
+---
+
+## .limits.create
+
+Create new usage limit(s).
+
+```bash
+iron .limits.create max_tokens::<n>
+iron .limits.create max_requests::<n>
+iron .limits.create max_cost::<n>
+iron .limits.create project::<id> max_tokens::<n>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `project::` | string | Project ID | - |
+| `max_tokens::` | integer | Max tokens per day | - |
+| `max_requests::` | integer | Max requests per minute | - |
+| `max_cost::` | integer | Max cost per month (cents) | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Created [limit_response](../parameter_types.md#limit_response)
+
+**Example**:
+```bash
+# create token limit
+iron .limits.create max_tokens::1000000
+# Limit created
+# ID: 4
+# Type: tokens/day
+# Max Value: 1,000,000
+
+# create request rate limit
+iron .limits.create max_requests::100
+# Limit created
+# ID: 5
+# Type: requests/minute
+# Max Value: 100
+
+# create cost limit (in cents)
+iron .limits.create max_cost::5000
+# Limit created
+# ID: 6
+# Type: cost/month
+# Max Value: $50.00
+
+# create limit for specific project
+iron .limits.create project::prod max_tokens::500000
+# Limit created for project: prod
+```
+
+---
+
+## .limits.update
+
+Update existing limit.
+
+```bash
+iron .limits.update limit_id::<id> max_tokens::<n>
+iron .limits.update limit_id::<id> max_requests::<n>
+iron .limits.update limit_id::<id> max_cost::<n>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `limit_id::` | [limit_id](../parameter_types.md#limit_id) | Numeric limit identifier | - |
+| `max_tokens::` | integer | New max tokens | - |
+| `max_requests::` | integer | New max requests | - |
+| `max_cost::` | integer | New max cost | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated [limit_response](../parameter_types.md#limit_response)
+
+**Example**:
+```bash
+iron .limits.update limit_id::1 max_tokens::2000000
+# Limit updated
+# ID: 1
+# Type: tokens/day
+# Max Value: 2,000,000 (was: 1,000,000)
+
+iron .limits.update limit_id::2 max_requests::200 format::json
+# {
+#   "id": 2,
+#   "type": "requests/minute",
+#   "max_value": 200,
+#   "previous_max_value": 100
+# }
+```
+
+---
+
+## .limits.delete
+
+Delete limit.
+
+```bash
+iron .limits.delete limit_id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `limit_id::` | [limit_id](../parameter_types.md#limit_id) | Numeric limit identifier | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [success_response](../parameter_types.md#success_response)
+
+**Example**:
+```bash
+iron .limits.delete limit_id::4
+# Limit deleted: 4
+```

--- a/module/iron_cli/docs/cli/entities/project.md
+++ b/module/iron_cli/docs/cli/entities/project.md
@@ -1,0 +1,74 @@
+# .project
+
+## .project.list
+
+List all projects.
+
+```bash
+iron .project.list
+iron .project.list format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of project objects
+
+**Example**:
+```bash
+iron .project.list
+# ┌──────────┬──────────────┬─────────────────────┐
+# │ ID       │ Name         │ Created             │
+# ├──────────┼──────────────┼─────────────────────┤
+# │ proj_1   │ Production   │ 2024-01-10T08:00:00Z│
+# │ proj_2   │ Development  │ 2024-01-05T12:00:00Z│
+# │ proj_3   │ Testing      │ 2024-01-01T10:00:00Z│
+# └──────────┴──────────────┴─────────────────────┘
+
+iron .project.list format::json
+# [
+#   {"id": "proj_1", "name": "Production", "created_at": "2024-01-10T08:00:00Z"},
+#   ...
+# ]
+```
+
+---
+
+## .project.get
+
+Get project details by ID.
+
+```bash
+iron .project.get id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [project_id](../parameter_types.md#project_id) | Project ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Project configuration object
+
+**Example**:
+```bash
+iron .project.get id::proj_1
+# Project: proj_1
+# ───────────────────────────────
+# Name: Production
+# Created: 2024-01-10T08:00:00Z
+#
+# Agents: 5
+# Providers: 2
+# Total Usage: $35.00
+
+iron .project.get id::proj_1 format::json
+# {
+#   "id": "proj_1",
+#   "name": "Production",
+#   "created_at": "2024-01-10T08:00:00Z",
+#   "agents_count": 5,
+#   "providers_count": 2,
+#   "total_usage": 35000000
+# }
+```

--- a/module/iron_cli/docs/cli/entities/provider.md
+++ b/module/iron_cli/docs/cli/entities/provider.md
@@ -1,0 +1,240 @@
+# .provider
+
+## .provider.list
+
+List all providers.
+
+```bash
+iron .provider.list
+iron .provider.list format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `v::` | integer (0-5) | Verbosity level | 1 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of [provider_response](../parameter_types.md#provider_response)
+
+**Example**:
+```bash
+iron .provider.list
+# ┌──────────┬───────────┬─────────────────────┬─────────────┐
+# │ ID       │ Provider  │ Endpoint            │ Description │
+# ├──────────┼───────────┼─────────────────────┼─────────────┤
+# │ prov1    │ openai    │ api.openai.com      │ Production  │
+# │ prov2    │ anthropic │ api.anthropic.com   │ Claude API  │
+# └──────────┴───────────┴─────────────────────┴─────────────┘
+
+iron .provider.list format::json
+```
+
+---
+
+## .provider.create
+
+Create new provider.
+
+```bash
+iron .provider.create provider::<type> ip_token::<key>
+iron .provider.create provider::<type> ip_token::<key> base_url::<url> description::<desc>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `provider::` | [provider_type](../parameter_types.md#provider_type) | Provider type (openai\|anthropic\|gemini\|xai) | - |
+| `ip_token::` | string (sensitive) | Inference Provider token | - |
+| `base_url::` | string | Custom API endpoint | - |
+| `description::` | string | Provider description | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Created [provider_response](../parameter_types.md#provider_response)
+
+**Example**:
+```bash
+iron .provider.create provider::openai ip_token::sk-xxx
+# Provider created
+# ID: prov_abc123
+# Provider: openai
+# Endpoint: api.openai.com (default)
+
+iron .provider.create provider::anthropic ip_token::sk-ant-xxx description::"Claude production"
+
+iron .provider.create provider::gemini ip_token::AIza-xxx description::"Gemini"
+
+iron .provider.create provider::xai ip_token::xai-xxx description::"Grok"
+
+# with custom endpoint
+iron .provider.create provider::openai ip_token::sk-xxx base_url::https://custom.openai.azure.com
+```
+
+---
+
+## .provider.get
+
+Get provider details by ID.
+
+```bash
+iron .provider.get id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [provider_response](../parameter_types.md#provider_response)
+
+**Example**:
+```bash
+iron .provider.get id::prov_abc123
+# Provider: prov_abc123
+# ───────────────────────────────
+# Type: openai
+# Endpoint: api.openai.com
+# Description: Production OpenAI
+# Created: 2024-01-15T10:30:00Z
+#
+# Assigned Agents: 3
+```
+
+---
+
+## .provider.update
+
+Update provider.
+
+```bash
+iron .provider.update id::<id> ip_token::<key>
+iron .provider.update id::<id> name::<name> endpoint::<url>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `name::` | string | New name | - |
+| `ip_token::` | string (sensitive) | New IP token | - |
+| `endpoint::` | string | New endpoint | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated [provider_response](../parameter_types.md#provider_response)
+
+**Example**:
+```bash
+iron .provider.update id::prov_abc123 ip_token::sk-new-xxx
+# Provider updated: prov_abc123
+# IP token updated
+
+iron .provider.update id::prov_abc123 endpoint::https://new-endpoint.openai.com
+# Provider updated: prov_abc123
+# Endpoint: https://new-endpoint.openai.com
+```
+
+---
+
+## .provider.delete
+
+Delete provider.
+
+```bash
+iron .provider.delete id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [success_response](../parameter_types.md#success_response)
+
+**Example**:
+```bash
+iron .provider.delete id::prov_abc123
+# Provider deleted: prov_abc123
+
+iron .provider.delete id::prov_abc123 dry::1
+# Would delete provider: prov_abc123 (dry run)
+```
+
+---
+
+## .provider.assign_agents
+
+Assign agents to provider.
+
+```bash
+iron .provider.assign_agents id::<id> agent_ids::<list>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `agent_ids::` | string | Comma-separated agent IDs | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated provider with assigned agents
+
+**Example**:
+```bash
+iron .provider.assign_agents id::prov_abc123 agent_ids::agent1,agent2
+# Agents assigned to provider: prov_abc123
+# Agents: agent1, agent2
+```
+
+---
+
+## .provider.list_agents
+
+List provider's agents.
+
+```bash
+iron .provider.list_agents id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of assigned agent objects
+
+**Example**:
+```bash
+iron .provider.list_agents id::prov_abc123
+# ┌──────────┬────────────┬────────┐
+# │ ID       │ Name       │ Status │
+# ├──────────┼────────────┼────────┤
+# │ agent1   │ my-agent   │ active │
+# │ agent2   │ prod-agent │ active │
+# └──────────┴────────────┴────────┘
+```
+
+---
+
+## .provider.remove_agent
+
+Remove agent from provider.
+
+```bash
+iron .provider.remove_agent id::<id> agent_id::<agent_id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [provider_id](../parameter_types.md#provider_id) | Provider ID | - |
+| `agent_id::` | string | Agent ID to remove | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated provider with agent removed
+
+**Example**:
+```bash
+iron .provider.remove_agent id::prov_abc123 agent_id::agent2
+# Agent removed from provider: prov_abc123
+# Removed: agent2
+```

--- a/module/iron_cli/docs/cli/entities/readme.md
+++ b/module/iron_cli/docs/cli/entities/readme.md
@@ -4,8 +4,6 @@
 
 ## Commands
 
-### Token API Commands (9 commands)
-
 | Command | Description | Params |
 |---------|-------------|--------|
 | `.auth.login` | Authenticate user and obtain JWT tokens | 3 |
@@ -17,11 +15,6 @@
 | `.limits.create` | Create new limit | 5 |
 | `.limits.update` | Update existing limit | 5 |
 | `.limits.delete` | Delete limit | 2 |
-
-### Control API Commands (33 commands)
-
-| Command | Description | Params |
-|---------|-------------|--------|
 | `.agent.list` | List all agents | 4 |
 | `.agent.create` | Create new agent | 6 |
 | `.agent.get` | Get agent details | 2 |
@@ -52,13 +45,54 @@
 | `.user.set_role` | Set user role | 4 |
 | `.user.reset_password` | Reset user password | 4 |
 | `.user.get_permissions` | Get user permissions | 2 |
-| `.auth.login` | Authenticate (Control API) | 3 |
-| `.auth.refresh` | Refresh token (Control API) | 1 |
-| `.auth.logout` | Logout (Control API) | 1 |
 
 See [parameter_groups.md](../parameter_groups.md) for shared parameters (output, pagination, dry_run).
 
 **Namespaces**: [.auth](auth.md) | [.tokens](tokens.md) | [.analytics](analytics.md) | [.limits](limits.md) | [.agent](agent.md) | [.provider](provider.md) | [.budget](budget.md) | [.project](project.md) | [.user](user.md)
+
+## Priority
+
+| Priority | Command |
+|----------|---------|
+| 1 | `.auth.login` |
+| 1 | `.auth.refresh` |
+| 1 | `.auth.logout` |
+| 2 | `.tokens` |
+| 3 | `.provider.list` |
+| 3 | `.provider.create` |
+| 3 | `.provider.get` |
+| 3 | `.provider.update` |
+| 3 | `.provider.delete` |
+| 4 | `.agent.list` |
+| 4 | `.agent.create` |
+| 4 | `.agent.get` |
+| 4 | `.agent.update` |
+| 4 | `.agent.delete` |
+| 4 | `.agent.assign_providers` |
+| 4 | `.agent.list_providers` |
+| 4 | `.agent.remove_provider` |
+| 4 | `.provider.assign_agents` |
+| 4 | `.provider.list_agents` |
+| 4 | `.provider.remove_agent` |
+| 5 | `.analytics` |
+| 6 | `.budget_limit.get` |
+| 6 | `.budget_limit.set` |
+| 6 | `.budget.status` |
+| 7 | `.limits.list` |
+| 7 | `.limits.get` |
+| 7 | `.limits.create` |
+| 7 | `.limits.update` |
+| 7 | `.limits.delete` |
+| 8 | `.user.list` |
+| 8 | `.user.create` |
+| 8 | `.user.get` |
+| 8 | `.user.update` |
+| 8 | `.user.delete` |
+| 8 | `.user.set_role` |
+| 8 | `.user.reset_password` |
+| 8 | `.user.get_permissions` |
+| 9 | `.project.list` |
+| 9 | `.project.get` |
 
 ## Files
 

--- a/module/iron_cli/docs/cli/entities/readme.md
+++ b/module/iron_cli/docs/cli/entities/readme.md
@@ -1,0 +1,76 @@
+# Iron CLI Reference
+
+**Version**: 0.4.0
+
+## Commands
+
+### Token API Commands (9 commands)
+
+| Command | Description | Params |
+|---------|-------------|--------|
+| `.auth.login` | Authenticate user and obtain JWT tokens | 3 |
+| `.auth.refresh` | Refresh access token | 1 |
+| `.auth.logout` | Invalidate tokens and clear keyring | 1 |
+| `.tokens` | Unified token management (api, ic types) | 12 |
+| `.limits.list` | List all limits | 1 |
+| `.limits.get` | Get limit details | 2 |
+| `.limits.create` | Create new limit | 5 |
+| `.limits.update` | Update existing limit | 5 |
+| `.limits.delete` | Delete limit | 2 |
+
+### Control API Commands (33 commands)
+
+| Command | Description | Params |
+|---------|-------------|--------|
+| `.agent.list` | List all agents | 4 |
+| `.agent.create` | Create new agent | 6 |
+| `.agent.get` | Get agent details | 2 |
+| `.agent.update` | Update agent | 5 |
+| `.agent.delete` | Delete agent | 3 |
+| `.agent.assign_providers` | Assign providers to agent | 4 |
+| `.agent.list_providers` | List agent's providers | 2 |
+| `.agent.remove_provider` | Remove provider from agent | 4 |
+| `.provider.list` | List all providers | 2 |
+| `.provider.create` | Create new provider | 6 |
+| `.provider.get` | Get provider details | 2 |
+| `.provider.update` | Update provider | 6 |
+| `.provider.delete` | Delete provider | 3 |
+| `.provider.assign_agents` | Assign agents to provider | 4 |
+| `.provider.list_agents` | List provider's agents | 2 |
+| `.provider.remove_agent` | Remove agent from provider | 4 |
+| `.analytics` | Unified analytics: metrics, usage, spending, traces | 11 |
+| `.budget_limit.get` | Get global budget limit | 1 |
+| `.budget_limit.set` | Set global budget limit | 3 |
+| `.budget.status` | Get budget status | 6 |
+| `.project.list` | List all projects | 1 |
+| `.project.get` | Get project details | 2 |
+| `.user.list` | List all users | 1 |
+| `.user.create` | Create new user | 6 |
+| `.user.get` | Get user details | 2 |
+| `.user.update` | Update user | 4 |
+| `.user.delete` | Delete user | 3 |
+| `.user.set_role` | Set user role | 4 |
+| `.user.reset_password` | Reset user password | 4 |
+| `.user.get_permissions` | Get user permissions | 2 |
+| `.auth.login` | Authenticate (Control API) | 3 |
+| `.auth.refresh` | Refresh token (Control API) | 1 |
+| `.auth.logout` | Logout (Control API) | 1 |
+
+See [parameter_groups.md](../parameter_groups.md) for shared parameters (output, pagination, dry_run).
+
+**Namespaces**: [.auth](auth.md) | [.tokens](tokens.md) | [.analytics](analytics.md) | [.limits](limits.md) | [.agent](agent.md) | [.provider](provider.md) | [.budget](budget.md) | [.project](project.md) | [.user](user.md)
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| auth.md | Authentication commands (`.auth.*`) |
+| tokens.md | Unified token management: api, ic types (`.tokens`) |
+| analytics.md | Unified analytics: metrics, usage, spending, traces (`.analytics`) |
+| limits.md | Limit management (`.limits.*`) |
+| agent.md | Agent management (`.agent.*`) |
+| provider.md | Provider management (`.provider.*`) |
+| budget.md | Budget management (`.budget.*`, `.budget_limit.*`) |
+| project.md | Project management (`.project.*`) |
+| user.md | User management (`.user.*`) |
+| readme.md | Command index |

--- a/module/iron_cli/docs/cli/entities/tokens.md
+++ b/module/iron_cli/docs/cli/entities/tokens.md
@@ -1,0 +1,136 @@
+# .tokens
+
+Unified token management for all token types.
+
+```bash
+iron .tokens
+iron .tokens type::<type>
+iron .tokens id::<id>
+iron .tokens generate type::<type> name::<name>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `type::` | enum | Token type: `api`, `ic` | - |
+| `id::` | string | Token ID (for get/rotate/revoke) | - |
+| `agent_id::` | string | Agent ID (required for type::ic) | - |
+| `name::` | string | Token name | - |
+| `scope::` | [scope](../parameter_types.md#scope) | Token scope (for type::api) | - |
+| `description::` | string | Token description | - |
+| `ttl::` | integer | Time-to-live in seconds | - |
+| `generate::` | flag | Generate new token | - |
+| `rotate::` | flag | Rotate existing token | - |
+| `revoke::` | flag | Revoke token | - |
+| `status::` | flag | Get token status (for IC tokens) | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Token types:**
+
+| Type | Description |
+|------|-------------|
+| `api` | API tokens for service authentication |
+| `ic` | IC tokens for agent authentication |
+
+---
+
+## List tokens
+
+```bash
+# list all tokens
+iron .tokens
+# ┌─────────────┬───────────┬──────────────┬────────┐
+# │ ID          │ Name      │ Type         │ Status │
+# ├─────────────┼───────────┼──────────────┼────────┤
+# │ tok_abc123  │ MyToken   │ api          │ active │
+# │ tok_def456  │ ProdKey   │ api          │ active │
+# │ ic_xyz789   │ my-agent  │ ic           │ active │
+# └─────────────┴───────────┴──────────────┴────────┘
+
+# filter by type
+iron .tokens type::api
+iron .tokens type::ic
+```
+
+---
+
+## Get token
+
+```bash
+iron .tokens id::tok_abc123
+# ID: tok_abc123
+# Name: MyToken
+# Type: api
+# Scope: read:tokens
+# Created: 2024-01-15T10:30:00Z
+# Expires: never
+# Status: active
+
+# IC token status
+iron .tokens id::ic_xyz789 status
+# ID: ic_xyz789
+# Agent: my-agent
+# Type: ic
+# Created: 2024-01-15T10:30:00Z
+# Last used: 2024-01-15T14:00:00Z
+# Status: active
+```
+
+---
+
+## Generate token
+
+```bash
+# API token
+iron .tokens generate type::api name::MyToken scope::read:tokens
+# Token created: tok_abc123
+# Name: MyToken
+# Type: api
+# Scope: read:tokens
+#
+# WARNING: Token value shown only once. Store it securely.
+# Token: sk_live_xxxxxxxxxxxxx
+
+# API token with TTL
+iron .tokens generate type::api name::TempToken scope::read:usage ttl::86400
+
+# IC token for agent
+iron .tokens generate type::ic agent_id::my-agent
+# IC Token created for agent: my-agent
+#
+# WARNING: Token value shown only once. Store it securely.
+# Token: ic_xxxxxxxxxxxxx
+```
+
+---
+
+## Rotate token
+
+Generate new value, revoke old.
+
+```bash
+iron .tokens id::tok_abc123 rotate
+# Token rotated: tok_abc123
+# Old token revoked
+#
+# WARNING: New token value shown only once. Store it securely.
+# Token: sk_live_newxxxxxxxxxxxxx
+
+# rotate with new TTL
+iron .tokens id::tok_abc123 rotate ttl::604800
+
+# rotate IC token
+iron .tokens id::ic_xyz789 rotate
+```
+
+---
+
+## Revoke token
+
+```bash
+iron .tokens id::tok_abc123 revoke
+# Token revoked: tok_abc123
+
+# revoke IC token
+iron .tokens id::ic_xyz789 revoke
+# IC Token revoked for agent: my-agent
+```

--- a/module/iron_cli/docs/cli/entities/user.md
+++ b/module/iron_cli/docs/cli/entities/user.md
@@ -1,0 +1,264 @@
+# .user
+
+## .user.list
+
+List all users.
+
+```bash
+iron .user.list
+iron .user.list format::json
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Array of [user_response](../parameter_types.md#user_response)
+
+**Example**:
+```bash
+iron .user.list
+# ┌──────────┬──────────┬────────────────────┬────────┐
+# │ ID       │ Username │ Email              │ Role   │
+# ├──────────┼──────────┼────────────────────┼────────┤
+# │ user_1   │ admin    │ admin@example.com  │ admin  │
+# │ user_2   │ alice    │ alice@example.com  │ user   │
+# │ user_3   │ bob      │ bob@example.com    │ user   │
+# └──────────┴──────────┴────────────────────┴────────┘
+
+iron .user.list format::json
+```
+
+---
+
+## .user.create
+
+Create new user.
+
+```bash
+iron .user.create username::<name> email::<email> password::<password>
+iron .user.create username::<name> email::<email> password::<password> role::admin
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `username::` | string | Username (3-50 chars) | - |
+| `email::` | [email](../parameter_types.md#email) | User email | - |
+| `password::` | string (sensitive) | Initial password | - |
+| `role::` | [role](../parameter_types.md#role) | User role (admin\|user) | `user` |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Created [user_response](../parameter_types.md#user_response)
+
+**Example**:
+```bash
+iron .user.create username::alice email::alice@example.com password::secret
+# User created
+# ID: user_xyz
+# Username: alice
+# Email: alice@example.com
+# Role: user
+
+# create admin user
+iron .user.create username::admin2 email::admin2@example.com password::secret role::admin
+# User created with admin role
+
+# interactive password prompt
+iron .user.create username::bob email::bob@example.com
+# Password: [hidden input]
+# User created
+```
+
+---
+
+## .user.get
+
+Get user details by ID.
+
+```bash
+iron .user.get id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [user_response](../parameter_types.md#user_response) with permissions
+
+**Example**:
+```bash
+iron .user.get id::user_1
+# User: user_1
+# ───────────────────────────────
+# Username: admin
+# Email: admin@example.com
+# Role: admin
+# Created: 2024-01-01T00:00:00Z
+#
+# Permissions: all
+
+iron .user.get id::user_1 format::json
+```
+
+---
+
+## .user.update
+
+Update user.
+
+```bash
+iron .user.update id::<id> email::<email>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `email::` | [email](../parameter_types.md#email) | New email | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated [user_response](../parameter_types.md#user_response)
+
+**Example**:
+```bash
+iron .user.update id::user_2 email::newalice@example.com
+# User updated: user_2
+# Email: newalice@example.com
+
+iron .user.update id::user_2 email::test@example.com dry::1
+# Would update user: user_2 (dry run)
+```
+
+---
+
+## .user.delete
+
+Delete user.
+
+```bash
+iron .user.delete id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: [success_response](../parameter_types.md#success_response)
+
+**Example**:
+```bash
+iron .user.delete id::user_3
+# User deleted: user_3
+
+iron .user.delete id::user_3 dry::1
+# Would delete user: user_3 (dry run)
+```
+
+---
+
+## .user.set_role
+
+Set user role.
+
+```bash
+iron .user.set_role id::<id> role::<role>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `role::` | [role](../parameter_types.md#role) | New role (admin\|user) | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Updated [user_response](../parameter_types.md#user_response)
+
+**Example**:
+```bash
+iron .user.set_role id::user_2 role::admin
+# User role updated: user_2
+# Role: admin
+
+iron .user.set_role id::user_2 role::user
+# User role updated: user_2
+# Role: user (demoted from admin)
+```
+
+---
+
+## .user.reset_password
+
+Reset user password.
+
+```bash
+iron .user.reset_password id::<id> new_password::<password>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `new_password::` | string (sensitive) | New password | - |
+| `dry::` | integer (0\|1) | Dry run flag | 0 |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: Password reset confirmation
+
+**Example**:
+```bash
+iron .user.reset_password id::user_2 new_password::newsecret
+# Password reset for user: user_2
+
+# interactive password prompt
+iron .user.reset_password id::user_2
+# New password: [hidden input]
+# Password reset for user: user_2
+```
+
+---
+
+## .user.get_permissions
+
+Get user permissions.
+
+```bash
+iron .user.get_permissions id::<id>
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id::` | [user_id](../parameter_types.md#user_id) | User ID | - |
+| `format::` | [format_output](../parameter_types.md#format_output) | Output format | `table` |
+
+**Response**: User permissions array
+
+**Example**:
+```bash
+iron .user.get_permissions id::user_1
+# Permissions for user: user_1 (admin)
+# ┌─────────────────────────┐
+# │ Permission              │
+# ├─────────────────────────┤
+# │ agents:read             │
+# │ agents:write            │
+# │ agents:delete           │
+# │ providers:read          │
+# │ providers:write         │
+# │ users:read              │
+# │ users:write             │
+# │ analytics:read          │
+# └─────────────────────────┘
+
+iron .user.get_permissions id::user_2
+# Permissions for user: user_2 (user)
+# ┌─────────────────────────┐
+# │ Permission              │
+# ├─────────────────────────┤
+# │ agents:read             │
+# │ providers:read          │
+# │ analytics:read          │
+# └─────────────────────────┘
+```

--- a/module/iron_cli/docs/cli/parameter_groups.md
+++ b/module/iron_cli/docs/cli/parameter_groups.md
@@ -1,0 +1,153 @@
+# Parameter Groups
+
+Shared parameters reused across command namespaces.
+
+## Overview
+
+| Group | Parameters | Used By |
+|-------|------------|---------|
+| `output` | `format::`, `v::` | all commands |
+| `pagination` | `page::`, `limit::` | list commands |
+| `dry_run` | `dry::` | mutation commands |
+| `authentication` | `email::`, `password::`, `username::` | auth commands |
+
+---
+
+## output
+
+| Parameter | Type | Description | Env |
+|-----------|------|-------------|-----|
+| `format::` | [format_output](parameter_types.md#format_output) | Output format | `IRON_FORMAT` |
+| `v::` | int (0-5) | Verbosity level | `IRON_VERBOSITY` |
+
+**Verbosity levels**:
+
+| Level | Description |
+|-------|-------------|
+| 0 | Silent (errors only) |
+| 1 | Normal (default) |
+| 2 | Verbose |
+| 3 | Debug |
+| 4 | Trace |
+| 5 | All |
+
+**Example**:
+```bash
+iron .tokens.list format::json
+iron .tokens.list v::2
+```
+
+---
+
+## pagination
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `page::` | int | Page number (1-based) | 1 |
+| `limit::` | int | Results per page | 20 |
+| `per_page::` | int | Alias for limit | 20 |
+
+Used by `.tokens.list`, `.agent.list`, `.provider.list`, `.user.list`.
+
+**Example**:
+```bash
+iron .tokens.list page::2 limit::50
+# Returns page 2 with up to 50 results
+
+iron .agent.list per_page::10
+# Returns first 10 agents
+```
+
+---
+
+## dry_run
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `dry::` | int (0\|1) | Dry run flag | 0 |
+
+Used by create, update, delete, assign, remove operations.
+
+- `dry::0` - Execute the operation (default)
+- `dry::1` - Preview only, show what would happen
+
+**Example**:
+```bash
+# preview deletion
+iron .agent.delete id::abc123 dry::1
+# Agent would be deleted: abc123 (dry run)
+
+# actually delete
+iron .agent.delete id::abc123
+# Agent deleted: abc123
+```
+
+---
+
+## authentication
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `email::` | [email](parameter_types.md#email) | Email for login | - |
+| `username::` | string | Username for login | - |
+| `password::` | string (sensitive) | User password | - |
+
+Used by `.auth.login`.
+
+**Notes**:
+- `password::` is marked as sensitive and supports interactive input
+- Tokens are stored in system keyring after successful login
+- Use either `email::` or `username::` for login
+
+**Example**:
+```bash
+# login with email
+iron .auth.login email::user@example.com password::secret
+
+# login with username (control API)
+iron .auth.login username::admin password::secret
+
+# interactive password prompt
+iron .auth.login email::user@example.com
+# Password: [hidden input]
+```
+
+---
+
+## filter
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `filter::` | string | Filter criteria | - |
+| `sort::` | string | Sort field | - |
+
+Used by list commands for filtering and sorting results.
+
+**Example**:
+```bash
+iron .tokens.list filter::active sort::created_at
+```
+
+---
+
+## export
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `export_format::` | [export_format](parameter_types.md#export_format) | Export data format | json |
+| `output::` | string | Output file path | stdout |
+| `output_file::` | string | Alias for output | stdout |
+
+Used by `.usage.export`, `.traces.export`, `.analytics.export_*`.
+
+**Example**:
+```bash
+# export to file
+iron .usage.export export_format::json output::usage.json
+
+# export to stdout
+iron .traces.export export_format::csv
+
+# analytics export
+iron .analytics.export_usage output_file::usage_report.csv format::csv
+```

--- a/module/iron_cli/docs/cli/parameter_types.md
+++ b/module/iron_cli/docs/cli/parameter_types.md
@@ -1,0 +1,469 @@
+# Parameter Types
+
+## Overview
+
+### Input Types
+
+| Type | Kind | Description |
+|------|------|-------------|
+| [`token_id`](#token_id) | string | `tok_abc123` |
+| [`agent_id`](#agent_id) | string | UUID format |
+| [`provider_id`](#provider_id) | string | Provider identifier |
+| [`user_id`](#user_id) | string | User identifier |
+| [`project_id`](#project_id) | string | Project identifier |
+| [`limit_id`](#limit_id) | integer | Numeric limit identifier |
+| [`trace_id`](#trace_id) | integer | Numeric trace identifier |
+| [`email`](#email) | string | `user@example.com` |
+| [`scope`](#scope) | string | `action:resource` format |
+| [`provider_type`](#provider_type) | enum | `openai \| anthropic \| gemini \| xai` |
+| [`role`](#role) | enum | `admin \| user` |
+| [`period`](#period) | enum | `day \| week \| month` |
+| [`format_output`](#format_output) | enum | `json \| table \| yaml` |
+| [`export_format`](#export_format) | enum | `json \| csv` |
+
+### Response Types
+
+| Type | Fields |
+|------|--------|
+| [`token_response`](#token_response) | `id`, `name`, `scope`, `created_at`, `expires_at`, `status` |
+| [`agent_response`](#agent_response) | `id`, `name`, `providers`, `budget`, `budget_used`, `status` |
+| [`provider_response`](#provider_response) | `id`, `provider`, `base_url`, `description`, `created_at` |
+| [`user_response`](#user_response) | `id`, `username`, `email`, `role`, `created_at` |
+| [`usage_response`](#usage_response) | `total_tokens`, `total_requests`, `total_cost`, `breakdown` |
+| [`limit_response`](#limit_response) | `id`, `type`, `max_value`, `time_window`, `current_value` |
+| [`trace_response`](#trace_response) | `id`, `token_id`, `provider`, `model`, `tokens`, `cost` |
+| [`success_response`](#success_response) | `message` |
+| [`error_response`](#error_response) | `error`, `code`, `details` |
+
+---
+
+## `token_id`
+
+API token identifier with `tok_` prefix.
+
+| Format | Example |
+|--------|---------|
+| `tok_*` | `tok_abc123xyz` |
+
+```bash
+token_id::tok_abc123xyz
+```
+
+---
+
+## `agent_id`
+
+Agent UUID identifier.
+
+| Format | Example |
+|--------|---------|
+| UUID | `550e8400-e29b-41d4-a716-446655440000` |
+
+```bash
+id::550e8400-e29b-41d4-a716-446655440000
+```
+
+---
+
+## `provider_id`
+
+Provider identifier string.
+
+```bash
+provider_id::prov_openai_123
+id::prov_openai_123
+```
+
+---
+
+## `user_id`
+
+User identifier string.
+
+```bash
+id::user_abc123
+```
+
+---
+
+## `project_id`
+
+Project identifier string.
+
+```bash
+project_id::proj_production
+project::prod
+```
+
+---
+
+## `limit_id`
+
+Numeric limit identifier.
+
+| Format | Example |
+|--------|---------|
+| integer | `789` |
+
+```bash
+limit_id::789
+```
+
+---
+
+## `trace_id`
+
+Numeric trace identifier.
+
+| Format | Example |
+|--------|---------|
+| integer | `999` |
+
+```bash
+trace_id::999
+```
+
+---
+
+## `email`
+
+Email address format.
+
+```bash
+email::user@example.com
+```
+
+---
+
+## `scope`
+
+Token permission scope in `action:resource` format.
+
+| Action | Resources | Example |
+|--------|-----------|---------|
+| `read` | tokens, usage, limits, traces | `read:tokens` |
+| `write` | tokens, limits | `write:tokens` |
+| `admin` | all | `admin:all` |
+
+```bash
+scope::read:tokens
+scope::write:limits
+scope::admin:all
+```
+
+---
+
+## `provider_type`
+
+LLM provider type.
+
+| Value | Description |
+|-------|-------------|
+| `openai` | OpenAI API |
+| `anthropic` | Anthropic Claude API |
+| `gemini` | Google Gemini API |
+| `xai` | xAI Grok API |
+
+```bash
+provider::openai
+provider::anthropic
+provider::gemini
+provider::xai
+```
+
+---
+
+## `role`
+
+User role for access control.
+
+| Value | Description |
+|-------|-------------|
+| `admin` | Full administrative access |
+| `user` | Standard user access |
+
+```bash
+role::admin
+role::user
+```
+
+---
+
+## `period`
+
+Time period for analytics.
+
+| Value | Description |
+|-------|-------------|
+| `day` | Daily aggregation |
+| `week` | Weekly aggregation |
+| `month` | Monthly aggregation |
+
+```bash
+period::day
+period::week
+period::month
+```
+
+---
+
+## `format_output`
+
+Output format for CLI responses.
+
+| Value | Description |
+|-------|-------------|
+| `json` | Machine-readable JSON |
+| `table` | ASCII table (default) |
+| `yaml` | YAML format |
+
+```bash
+format::json
+format::table
+format::yaml
+```
+
+---
+
+## `export_format`
+
+Data export format.
+
+| Value | Description |
+|-------|-------------|
+| `json` | JSON export (default) |
+| `csv` | CSV export |
+
+```bash
+export_format::json
+export_format::csv
+```
+
+---
+
+## `token_response`
+
+Response from `.tokens.generate`, `.tokens.get`, `.tokens.list`, `.tokens.rotate`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Token ID (tok_xxx) |
+| `name` | string | Token name |
+| `scope` | string | Permission scope |
+| `project_id` | string? | Associated project |
+| `created_at` | ISO8601 | Creation timestamp |
+| `expires_at` | ISO8601? | Expiration timestamp |
+| `last_used_at` | ISO8601? | Last usage timestamp |
+| `status` | string | `active` or `revoked` |
+
+```bash
+iron .tokens.get token_id::tok_abc123 format::json
+# {
+#   "id": "tok_abc123",
+#   "name": "MyToken",
+#   "scope": "read:tokens",
+#   "project_id": null,
+#   "created_at": "2024-01-15T10:30:00Z",
+#   "expires_at": "2024-07-15T10:30:00Z",
+#   "status": "active"
+# }
+```
+
+---
+
+## `agent_response`
+
+Response from `.agent.create`, `.agent.get`, `.agent.list`, `.agent.update`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Agent UUID |
+| `name` | string | Agent name |
+| `providers` | string[] | Assigned providers |
+| `budget` | integer | Budget in microdollars |
+| `budget_used` | integer | Used budget |
+| `budget_remaining` | integer | Remaining budget |
+| `created_at` | ISO8601 | Creation timestamp |
+| `updated_at` | ISO8601 | Last update timestamp |
+| `status` | string | `active`, `paused`, or `deleted` |
+
+```bash
+iron .agent.get id::abc123 format::json
+# {
+#   "id": "abc123",
+#   "name": "my-agent",
+#   "providers": ["openai"],
+#   "budget": 1000000,
+#   "budget_used": 250000,
+#   "budget_remaining": 750000,
+#   "status": "active"
+# }
+```
+
+---
+
+## `provider_response`
+
+Response from `.provider.create`, `.provider.get`, `.provider.list`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Provider ID |
+| `provider` | string | Provider type (openai, anthropic) |
+| `base_url` | string? | Custom API endpoint |
+| `description` | string? | Provider description |
+| `created_at` | ISO8601 | Creation timestamp |
+
+---
+
+## `user_response`
+
+Response from `.user.create`, `.user.get`, `.user.list`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | User ID |
+| `username` | string | Username |
+| `email` | string | Email address |
+| `role` | string | User role |
+| `created_at` | ISO8601 | Creation timestamp |
+
+---
+
+## `usage_response`
+
+Response from `.usage.show`, `.usage.by_project`, `.usage.by_provider`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_tokens` | integer | Total tokens consumed |
+| `total_requests` | integer | Total API requests |
+| `total_cost` | decimal | Total cost in dollars |
+| `breakdown` | object | Usage by provider/project |
+| `period` | object | Time range (from, to) |
+
+```bash
+iron .usage.show format::json
+# {
+#   "total_tokens": 1500000,
+#   "total_requests": 450,
+#   "total_cost": 15.50,
+#   "breakdown": {
+#     "by_provider": {"openai": {...}, "anthropic": {...}},
+#     "by_project": {"prod": {...}}
+#   }
+# }
+```
+
+---
+
+## `limit_response`
+
+Response from `.limits.list`, `.limits.get`, `.limits.create`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Limit ID |
+| `type` | string | Limit type (tokens, requests, cost) |
+| `max_value` | integer | Maximum allowed value |
+| `time_window` | string | Time window (minute, day, month) |
+| `current_value` | integer | Current usage |
+
+---
+
+## `trace_response`
+
+Response from `.traces.list`, `.traces.get`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Trace ID |
+| `token_id` | string | Associated token |
+| `provider` | string | Provider used |
+| `model` | string | Model used |
+| `prompt_tokens` | integer | Input tokens |
+| `completion_tokens` | integer | Output tokens |
+| `total_tokens` | integer | Total tokens |
+| `cost` | decimal | Request cost |
+| `timestamp` | ISO8601 | Request timestamp |
+
+---
+
+## `success_response`
+
+Response for operations that don't return data.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | string | Human-readable status message |
+
+```bash
+iron .tokens.revoke token_id::tok_abc123
+# {"message": "Token revoked: tok_abc123"}
+```
+
+---
+
+## `error_response`
+
+Error response structure.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | string | Error message |
+| `code` | string | Error code |
+| `details` | object? | Additional error details |
+
+```bash
+# {
+#   "error": "Token not found",
+#   "code": "not_found",
+#   "details": {"token_id": "tok_invalid"}
+# }
+```
+
+---
+
+## Parameter Resolution
+
+Parameters are resolved in order of priority:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | Explicit value | `format::json` |
+| 2 | Environment variable | `IRON_FORMAT` |
+| 3 | Default value | `format::table` |
+| 4 | Error | required param missing |
+
+```bash
+# explicit overrides env
+export IRON_FORMAT=json
+iron .tokens.list format::table  # uses "table"
+
+# env used when explicit missing
+iron .tokens.list  # uses IRON_FORMAT=json
+
+# default used when both missing
+unset IRON_FORMAT
+iron .tokens.list  # format::table by default
+```
+
+---
+
+## Environment Variables
+
+Any parameter can be set via environment variable with `IRON_` prefix:
+
+```
+param::<value>  ->  IRON_<PARAM>=<value>
+```
+
+**Example**:
+```bash
+export IRON_FORMAT=json
+export IRON_VERBOSITY=2
+
+# all these use env values
+iron .tokens.list
+iron .usage.show
+```

--- a/module/iron_cli/docs/cli/readme.md
+++ b/module/iron_cli/docs/cli/readme.md
@@ -1,0 +1,10 @@
+# CLI Documentation
+
+## Responsibility Table
+
+| File | Responsibility |
+|------|----------------|
+| [`entities/`](entities/readme.md) | Command reference by namespace |
+| [`parameter_types.md`](parameter_types.md) | Types, formats, identifiers |
+| [`parameter_groups.md`](parameter_groups.md) | Shared parameters (output, pagination, authentication) |
+| [`dictionary.md`](dictionary.md) | All terms and definitions |


### PR DESCRIPTION
Includes command reference, parameter types, dictionary, and entity docs for auth, tokens, analytics, agents, providers, users, projects, budgets, and limits.