### PR TITLE
NOT READY : Add server proxy, analytics enhancements, and multi-provider support

### DIFF
--- a/module/iron_control_api/src/bin/iron_control_api_server.rs
+++ b/module/iron_control_api/src/bin/iron_control_api_server.rs
@@ -758,6 +758,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
       put(routes::agents::update_agent_budget),
     )
     .route(
+      "/api/v1/agents/{id}/spending-cap",
+      put(routes::agents::set_agent_spending_cap),
+    )
+    .route(
       "/api/v1/agents/{id}/tokens",
       get(routes::agents::get_agent_tokens),
     )

--- a/module/iron_control_api/src/routes/agents.rs
+++ b/module/iron_control_api/src/routes/agents.rs
@@ -9,6 +9,7 @@
 //! - `POST /agents` - Create agent (admin only)
 //! - `PUT /agents/{id}` - Update agent (admin only)
 //! - `DELETE /agents/{id}` - Delete agent (admin only)
+//! - `PUT /agents/{id}/spending-cap` - Set or remove spending cap (admin only)
 //!
 //! **Access Control:**
 //! - Admins: Full access to all agents
@@ -832,4 +833,113 @@ pub async fn get_agent_tokens(
     .collect();
 
   Ok(Json(tokens))
+}
+
+/// Request body for setting agent spending cap
+#[derive(Debug, Deserialize)]
+pub struct SetSpendingCapRequest {
+  /// Spending cap in USD (null or absent = unlimited)
+  pub spending_cap_usd: Option<f64>,
+}
+
+/// Response body for agent spending information
+#[derive(Debug, Serialize)]
+pub struct AgentSpendingResponse {
+  /// Agent identifier
+  pub agent_id: i64,
+  /// Spending cap status
+  pub spending_cap: SpendingCapResponse,
+  /// Current spending in USD
+  pub spending_used_usd: f64,
+}
+
+/// Spending cap in the API response
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum SpendingCapResponse {
+  /// No limit
+  #[serde(rename = "unlimited")]
+  Unlimited,
+  /// Capped at a specific amount
+  #[serde(rename = "limited")]
+  Limited {
+    /// Cap amount in USD
+    cap_usd: f64,
+  },
+}
+
+/// PUT /api/v1/agents/{id}/spending-cap
+///
+/// Set or remove agent spending cap (admin only).
+///
+/// # Errors
+///
+/// Returns `(StatusCode, String)` if user is not admin, agent not found,
+/// or on database failure.
+pub async fn set_agent_spending_cap(
+  State(pool): State<SqlitePool>,
+  Path(id): Path<i64>,
+  user: AuthenticatedUser,
+  Json(req): Json<SetSpendingCapRequest>,
+) -> Result<Json<AgentSpendingResponse>, (StatusCode, String)> {
+  if user.0.role != "admin" {
+    return Err((
+      StatusCode::FORBIDDEN,
+      "Only administrators can set spending caps".to_string(),
+    ));
+  }
+
+  // Validate cap if provided
+  if let Some(cap) = req.spending_cap_usd {
+    if cap < 0.0 {
+      return Err((
+        StatusCode::BAD_REQUEST,
+        "spending_cap_usd cannot be negative".to_string(),
+      ));
+    }
+  }
+
+  let manager = iron_token_manager::agent_budget::AgentBudgetManager::from_pool(pool.clone());
+
+  let cap = match req.spending_cap_usd {
+    Some(usd) => iron_token_manager::SpendingCap::Limited(usd_to_microdollars(usd)),
+    None => iron_token_manager::SpendingCap::Unlimited,
+  };
+
+  manager.set_spending_cap(id, cap).await.map_err(|e| match e {
+    iron_token_manager::error::TokenError::NotFound => {
+      (StatusCode::NOT_FOUND, "Agent budget not found".to_string())
+    }
+    _ => (
+      StatusCode::INTERNAL_SERVER_ERROR,
+      format!("Database error: {e}"),
+    ),
+  })?;
+
+  let summary = manager.get_spending_summary(id).await.map_err(|e| {
+    (
+      StatusCode::INTERNAL_SERVER_ERROR,
+      format!("Database error: {e}"),
+    )
+  })?;
+
+  Ok(Json(AgentSpendingResponse {
+    agent_id: id,
+    spending_cap: match summary.cap {
+      iron_token_manager::SpendingCap::Unlimited => SpendingCapResponse::Unlimited,
+      iron_token_manager::SpendingCap::Limited(v) => SpendingCapResponse::Limited {
+        cap_usd: microdollars_to_usd(v),
+      },
+    },
+    spending_used_usd: microdollars_to_usd(summary.used_microdollars),
+  }))
+}
+
+fn microdollars_to_usd(microdollars: i64) -> f64 {
+  microdollars as f64 / 1_000_000.0
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn usd_to_microdollars(usd: f64) -> i64 {
+  (usd * 1_000_000.0) as i64
 }

--- a/module/iron_control_api/src/routes/analytics/ingestion.rs
+++ b/module/iron_control_api/src/routes/analytics/ingestion.rs
@@ -82,8 +82,8 @@ pub async fn post_event(
     r"INSERT OR IGNORE INTO analytics_events
        (event_id, timestamp_ms, event_type, model, provider,
         input_tokens, output_tokens, cost_micros,
-        agent_id, provider_id, error_code, error_message, received_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        agent_id, provider_id, error_code, error_message, provider_key_id, received_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
   )
   .bind(&event.event_id)
   .bind(event.timestamp_ms)
@@ -97,6 +97,7 @@ pub async fn post_event(
   .bind(&event.provider_id)
   .bind(&event.error_code)
   .bind(&event.error_message)
+  .bind(event.provider_key_id)
   .bind(now_ms)
   .execute(&state.pool)
   .await;
@@ -189,7 +190,7 @@ pub async fn list_events(
          e.event_id, e.timestamp_ms, e.event_type, e.model, e.provider,
          e.input_tokens, e.output_tokens, e.cost_micros, e.agent_id,
          COALESCE(a.name, 'Unknown') as agent_name,
-         e.error_code, e.error_message
+         e.error_code, e.error_message, e.provider_key_id
        FROM analytics_events e
        LEFT JOIN agents a ON e.agent_id = a.id
        WHERE e.timestamp_ms >= ? AND e.timestamp_ms <= ? AND e.agent_id = ?
@@ -200,7 +201,7 @@ pub async fn list_events(
          e.event_id, e.timestamp_ms, e.event_type, e.model, e.provider,
          e.input_tokens, e.output_tokens, e.cost_micros, e.agent_id,
          COALESCE(a.name, 'Unknown') as agent_name,
-         e.error_code, e.error_message
+         e.error_code, e.error_message, e.provider_key_id
        FROM analytics_events e
        LEFT JOIN agents a ON e.agent_id = a.id
        WHERE e.timestamp_ms >= ? AND e.timestamp_ms <= ?

--- a/module/iron_control_api/src/routes/analytics/ingestion.rs
+++ b/module/iron_control_api/src/routes/analytics/ingestion.rs
@@ -50,12 +50,17 @@ pub async fn post_event(
   }
 
   // Validate provider
-  if event.provider != "openai" && event.provider != "anthropic" && event.provider != "unknown" {
+  if event.provider != "openai"
+    && event.provider != "anthropic"
+    && event.provider != "gemini"
+    && event.provider != "xai"
+    && event.provider != "unknown"
+  {
     return (
       StatusCode::BAD_REQUEST,
       Json(serde_json::json!({
         "error": "VALIDATION_ERROR",
-        "message": "provider must be 'openai', 'anthropic', or 'unknown'"
+        "message": "provider must be 'openai', 'anthropic', 'gemini', 'xai', or 'unknown'"
       })),
     )
       .into_response();

--- a/module/iron_control_api/src/routes/analytics/mod.rs
+++ b/module/iron_control_api/src/routes/analytics/mod.rs
@@ -31,9 +31,9 @@ pub use shared::{
   AnalyticsState, AvgCostResponse, BudgetStatus, BudgetStatusQuery, BudgetStatusResponse,
   BudgetSummary, EventResponse, EventsListQuery, EventsListResponse, Filters, ModelUsage,
   ModelUsageResponse, ModelUsageSummary, Pagination, PaginationQuery, Period, ProviderSpending,
-  ProviderSpendingSummary, RequestUsageResponse, SpendingByAgentResponse,
-  SpendingByProviderResponse, SpendingSummary, SpendingTotalResponse, TokenUsageResponse,
-  TokenUsageSummary,
+  ProviderSpendingSummary, RequestUsageComparison, RequestUsageResponse, SpendingByAgentResponse,
+  SpendingByProviderResponse, SpendingSummary, SpendingTotalComparison, SpendingTotalResponse,
+  TokenUsageResponse, TokenUsageSummary,
 };
 
 pub use budget::get_budget_status;

--- a/module/iron_control_api/src/routes/analytics/shared.rs
+++ b/module/iron_control_api/src/routes/analytics/shared.rs
@@ -47,7 +47,129 @@ pub enum Period {
   AllTime,
 }
 
+/// Compute the percentage change between two values.
+///
+/// Returns `None` when the previous value is zero and current is non-zero
+/// (infinite change). Returns `Some(0.0)` when both are zero.
+#[must_use]
+pub fn compute_change_percent(current: f64, previous: f64) -> Option<f64> {
+  if previous == 0.0 {
+    if current == 0.0 {
+      Some(0.0)
+    } else {
+      None
+    }
+  } else {
+    Some(((current - previous) / previous) * 100.0)
+  }
+}
+
 impl Period {
+  /// Compute the previous period's time range for period-over-period comparison.
+  ///
+  /// Returns `None` for `AllTime` (no meaningful previous period).
+  ///
+  /// # Panics
+  ///
+  /// May panic if time calculations produce invalid dates, which should never
+  /// happen in practice (e.g., midnight is always valid, day 1 always exists).
+  #[must_use]
+  pub fn previous_period_range(&self) -> Option<(i64, i64)> {
+    let now = Utc::now();
+
+    match self {
+      Period::AllTime => None,
+      Period::Today => {
+        // Previous = yesterday (midnight to midnight)
+        let yesterday = (now - Duration::days(1)).date_naive();
+        let start = yesterday
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let end = now
+          .date_naive()
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let start_ms = DateTime::<Utc>::from_naive_utc_and_offset(start, Utc).timestamp_millis();
+        let end_ms =
+          DateTime::<Utc>::from_naive_utc_and_offset(end, Utc).timestamp_millis() - 1;
+        Some((start_ms, end_ms))
+      }
+      Period::Yesterday => {
+        // Previous = day before yesterday
+        let dby = (now - Duration::days(2)).date_naive();
+        let start = dby
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let yesterday = (now - Duration::days(1)).date_naive();
+        let end = yesterday
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let start_ms = DateTime::<Utc>::from_naive_utc_and_offset(start, Utc).timestamp_millis();
+        let end_ms =
+          DateTime::<Utc>::from_naive_utc_and_offset(end, Utc).timestamp_millis() - 1;
+        Some((start_ms, end_ms))
+      }
+      Period::Last7Days => {
+        // Current: (now-7d, now). Previous: (now-14d, now-7d)
+        let prev_start = (now - Duration::days(14)).timestamp_millis();
+        let prev_end = (now - Duration::days(7)).timestamp_millis() - 1;
+        Some((prev_start, prev_end))
+      }
+      Period::Last30Days => {
+        // Current: (now-30d, now). Previous: (now-60d, now-30d)
+        let prev_start = (now - Duration::days(60)).timestamp_millis();
+        let prev_end = (now - Duration::days(30)).timestamp_millis() - 1;
+        Some((prev_start, prev_end))
+      }
+      Period::ThisMonth => {
+        // Previous = last month
+        let first_of_this = now
+          .date_naive()
+          .with_day(1)
+          .expect("INVARIANT: day 1 is valid for all months");
+        let last_month_any_day = first_of_this - Duration::days(1);
+        let first_of_last = last_month_any_day
+          .with_day(1)
+          .expect("INVARIANT: day 1 is valid for all months");
+        let start = first_of_last
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let end = first_of_this
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let start_ms = DateTime::<Utc>::from_naive_utc_and_offset(start, Utc).timestamp_millis();
+        let end_ms =
+          DateTime::<Utc>::from_naive_utc_and_offset(end, Utc).timestamp_millis() - 1;
+        Some((start_ms, end_ms))
+      }
+      Period::LastMonth => {
+        // Previous = month before last
+        let first_of_this = now
+          .date_naive()
+          .with_day(1)
+          .expect("INVARIANT: day 1 is valid for all months");
+        let last_month_any_day = first_of_this - Duration::days(1);
+        let first_of_last = last_month_any_day
+          .with_day(1)
+          .expect("INVARIANT: day 1 is valid for all months");
+        let before_last_any_day = first_of_last - Duration::days(1);
+        let first_of_before = before_last_any_day
+          .with_day(1)
+          .expect("INVARIANT: day 1 is valid for all months");
+        let start = first_of_before
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let end = first_of_last
+          .and_hms_opt(0, 0, 0)
+          .expect("INVARIANT: midnight (00:00:00) is always valid");
+        let start_ms = DateTime::<Utc>::from_naive_utc_and_offset(start, Utc).timestamp_millis();
+        let end_ms =
+          DateTime::<Utc>::from_naive_utc_and_offset(end, Utc).timestamp_millis() - 1;
+        Some((start_ms, end_ms))
+      }
+    }
+  }
+
   /// Convert period to (`start_ms`, `end_ms`) range
   ///
   /// # Panics
@@ -143,6 +265,9 @@ pub struct AnalyticsQuery {
   pub provider_id: Option<String>,
   /// Optional provider key ID filter
   pub provider_key_id: Option<i64>,
+  /// Include previous period comparison data
+  #[serde(default)]
+  pub compare: bool,
 }
 
 /// Pagination parameters
@@ -279,6 +404,15 @@ impl Pagination {
   }
 }
 
+/// Previous period comparison data for spending total
+#[derive(Debug, Serialize)]
+pub struct SpendingTotalComparison {
+  /// Previous period total spending in dollars
+  pub total_spend: f64,
+  /// Percentage change from previous to current period (null if previous is zero)
+  pub change_percent: Option<f64>,
+}
+
 /// GET /api/v1/analytics/spending/total - Response
 #[derive(Debug, Serialize)]
 pub struct SpendingTotalResponse {
@@ -290,6 +424,9 @@ pub struct SpendingTotalResponse {
   pub period: String,
   /// Filters applied to query
   pub filters: Filters,
+  /// Previous period comparison (only present when compare=true)
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub previous_period: Option<SpendingTotalComparison>,
   /// ISO 8601 timestamp when calculated
   pub calculated_at: String,
 }
@@ -450,6 +587,21 @@ pub struct BudgetStatusResponse {
   pub calculated_at: String,
 }
 
+/// Previous period comparison data for request usage
+#[derive(Debug, Serialize)]
+pub struct RequestUsageComparison {
+  /// Previous period total requests
+  pub total_requests: i64,
+  /// Previous period successful requests
+  pub successful_requests: i64,
+  /// Previous period failed requests
+  pub failed_requests: i64,
+  /// Previous period success rate as percentage
+  pub success_rate: f64,
+  /// Percentage change in total requests from previous to current period
+  pub change_percent: Option<f64>,
+}
+
 /// GET /api/v1/analytics/usage/requests - Response
 #[derive(Debug, Serialize)]
 pub struct RequestUsageResponse {
@@ -465,6 +617,9 @@ pub struct RequestUsageResponse {
   pub period: String,
   /// Filters applied to query
   pub filters: Filters,
+  /// Previous period comparison (only present when compare=true)
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub previous_period: Option<RequestUsageComparison>,
   /// ISO 8601 timestamp when calculated
   pub calculated_at: String,
 }
@@ -682,4 +837,299 @@ pub struct AgentBudgetRow {
   pub total_allocated: i64,
   pub total_spent: i64,
   pub budget_remaining: i64,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json;
+
+  // ========================================================================
+  // compute_change_percent tests
+  // ========================================================================
+
+  #[test]
+  fn change_percent_both_zero() {
+    assert_eq!(compute_change_percent(0.0, 0.0), Some(0.0));
+  }
+
+  #[test]
+  fn change_percent_previous_zero_current_positive() {
+    assert_eq!(compute_change_percent(5.0, 0.0), None);
+  }
+
+  #[test]
+  fn change_percent_previous_zero_current_negative() {
+    assert_eq!(compute_change_percent(-3.0, 0.0), None);
+  }
+
+  #[test]
+  fn change_percent_normal_increase() {
+    let result = compute_change_percent(13.0, 10.0).unwrap();
+    assert!((result - 30.0).abs() < f64::EPSILON, "expected 30.0, got {result}");
+  }
+
+  #[test]
+  fn change_percent_normal_decrease() {
+    let result = compute_change_percent(7.0, 10.0).unwrap();
+    assert!((result - (-30.0)).abs() < f64::EPSILON, "expected -30.0, got {result}");
+  }
+
+  #[test]
+  fn change_percent_no_change() {
+    let result = compute_change_percent(10.0, 10.0).unwrap();
+    assert!((result - 0.0).abs() < f64::EPSILON, "expected 0.0, got {result}");
+  }
+
+  #[test]
+  fn change_percent_large_change() {
+    let result = compute_change_percent(100.0, 1.0).unwrap();
+    assert!((result - 9900.0).abs() < f64::EPSILON, "expected 9900.0, got {result}");
+  }
+
+  // ========================================================================
+  // previous_period_range tests
+  // ========================================================================
+
+  #[test]
+  fn previous_period_alltime_returns_none() {
+    assert!(Period::AllTime.previous_period_range().is_none());
+  }
+
+  #[test]
+  fn previous_period_today_returns_valid_range() {
+    let range = Period::Today.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end, "start ({start}) should be < end ({end})");
+
+    let current = Period::Today.to_range();
+    assert!(end < current.0, "previous end ({end}) should be < current start ({})", current.0);
+  }
+
+  #[test]
+  fn previous_period_yesterday_returns_valid_range() {
+    let range = Period::Yesterday.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end);
+
+    let current = Period::Yesterday.to_range();
+    assert!(end < current.0, "previous end ({end}) should be < current start ({})", current.0);
+  }
+
+  #[test]
+  fn previous_period_last7days_returns_valid_range() {
+    let range = Period::Last7Days.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end);
+
+    let current = Period::Last7Days.to_range();
+    assert!(end < current.0);
+
+    // Duration should be ~7 days (7 * 86400 * 1000 ms = 604_800_000)
+    let duration_ms = end - start;
+    let seven_days_ms: i64 = 7 * 24 * 60 * 60 * 1000;
+    // Allow 1 second tolerance for the -1 ms adjustment
+    assert!(
+      (duration_ms - seven_days_ms).abs() < 1000,
+      "duration {duration_ms} should be ~{seven_days_ms}"
+    );
+  }
+
+  #[test]
+  fn previous_period_last30days_returns_valid_range() {
+    let range = Period::Last30Days.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end);
+
+    let current = Period::Last30Days.to_range();
+    assert!(end < current.0);
+
+    // Duration should be ~30 days
+    let duration_ms = end - start;
+    let thirty_days_ms: i64 = 30 * 24 * 60 * 60 * 1000;
+    assert!(
+      (duration_ms - thirty_days_ms).abs() < 1000,
+      "duration {duration_ms} should be ~{thirty_days_ms}"
+    );
+  }
+
+  #[test]
+  fn previous_period_this_month_returns_valid_range() {
+    let range = Period::ThisMonth.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end);
+
+    let current = Period::ThisMonth.to_range();
+    assert!(end < current.0);
+  }
+
+  #[test]
+  fn previous_period_last_month_returns_valid_range() {
+    let range = Period::LastMonth.previous_period_range();
+    assert!(range.is_some());
+    let (start, end) = range.unwrap();
+    assert!(start < end);
+
+    let current = Period::LastMonth.to_range();
+    assert!(end < current.0);
+  }
+
+  #[test]
+  fn previous_period_non_negative_durations() {
+    let periods = [
+      Period::Today,
+      Period::Yesterday,
+      Period::Last7Days,
+      Period::Last30Days,
+      Period::ThisMonth,
+      Period::LastMonth,
+    ];
+    for period in &periods {
+      if let Some((start, end)) = period.previous_period_range() {
+        assert!(end >= start, "{period:?}: end ({end}) >= start ({start})");
+      }
+    }
+  }
+
+  #[test]
+  fn today_previous_matches_yesterday_range() {
+    let today_prev = Period::Today.previous_period_range().unwrap();
+    let yesterday_range = Period::Yesterday.to_range();
+    assert_eq!(
+      today_prev, yesterday_range,
+      "Today's previous period {today_prev:?} should equal Yesterday's range {yesterday_range:?}"
+    );
+  }
+
+  // ========================================================================
+  // Serde serialization tests
+  // ========================================================================
+
+  fn make_filters() -> Filters {
+    Filters {
+      agent_id: None,
+      provider_id: None,
+      provider_key_id: None,
+    }
+  }
+
+  #[test]
+  fn spending_total_response_without_previous_period() {
+    let resp = SpendingTotalResponse {
+      total_spend: 42.5,
+      currency: "USD".to_string(),
+      period: "last-7-days".to_string(),
+      filters: make_filters(),
+      previous_period: None,
+      calculated_at: "2026-01-01T00:00:00Z".to_string(),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    assert!(
+      json.get("previous_period").is_none(),
+      "previous_period should be absent when None"
+    );
+  }
+
+  #[test]
+  fn spending_total_response_with_previous_period() {
+    let resp = SpendingTotalResponse {
+      total_spend: 42.5,
+      currency: "USD".to_string(),
+      period: "last-7-days".to_string(),
+      filters: make_filters(),
+      previous_period: Some(SpendingTotalComparison {
+        total_spend: 30.0,
+        change_percent: Some(41.67),
+      }),
+      calculated_at: "2026-01-01T00:00:00Z".to_string(),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    let prev = json.get("previous_period").expect("previous_period should be present");
+    assert_eq!(prev["total_spend"], 30.0);
+    assert_eq!(prev["change_percent"], 41.67);
+  }
+
+  #[test]
+  fn request_usage_response_without_previous_period() {
+    let resp = RequestUsageResponse {
+      total_requests: 100,
+      successful_requests: 95,
+      failed_requests: 5,
+      success_rate: 0.95,
+      period: "today".to_string(),
+      filters: make_filters(),
+      previous_period: None,
+      calculated_at: "2026-01-01T00:00:00Z".to_string(),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    assert!(
+      json.get("previous_period").is_none(),
+      "previous_period should be absent when None"
+    );
+  }
+
+  #[test]
+  fn request_usage_response_with_previous_period() {
+    let resp = RequestUsageResponse {
+      total_requests: 100,
+      successful_requests: 95,
+      failed_requests: 5,
+      success_rate: 0.95,
+      period: "today".to_string(),
+      filters: make_filters(),
+      previous_period: Some(RequestUsageComparison {
+        total_requests: 80,
+        successful_requests: 75,
+        failed_requests: 5,
+        success_rate: 0.9375,
+        change_percent: Some(25.0),
+      }),
+      calculated_at: "2026-01-01T00:00:00Z".to_string(),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    let prev = json.get("previous_period").expect("previous_period should be present");
+    assert_eq!(prev["total_requests"], 80);
+    assert_eq!(prev["change_percent"], 25.0);
+  }
+
+  #[test]
+  fn change_percent_null_in_json() {
+    let comp = SpendingTotalComparison {
+      total_spend: 10.0,
+      change_percent: None,
+    };
+    let json = serde_json::to_value(&comp).unwrap();
+    assert!(
+      json["change_percent"].is_null(),
+      "change_percent: None should serialize as null"
+    );
+  }
+
+  // ========================================================================
+  // AnalyticsQuery deserialization tests
+  // ========================================================================
+
+  #[test]
+  fn analytics_query_default_compare_false() {
+    // Empty JSON object should use defaults
+    let q: AnalyticsQuery = serde_json::from_str("{}").unwrap();
+    assert!(!q.compare, "default compare should be false");
+  }
+
+  #[test]
+  fn analytics_query_compare_true() {
+    let q: AnalyticsQuery = serde_json::from_str(r#"{"compare": true}"#).unwrap();
+    assert!(q.compare);
+  }
+
+  #[test]
+  fn analytics_query_compare_false() {
+    let q: AnalyticsQuery = serde_json::from_str(r#"{"compare": false}"#).unwrap();
+    assert!(!q.compare);
+  }
 }

--- a/module/iron_control_api/src/routes/analytics/shared.rs
+++ b/module/iron_control_api/src/routes/analytics/shared.rs
@@ -141,6 +141,8 @@ pub struct AnalyticsQuery {
   pub agent_id: Option<i64>,
   /// Optional provider ID filter
   pub provider_id: Option<String>,
+  /// Optional provider key ID filter
+  pub provider_key_id: Option<i64>,
 }
 
 /// Pagination parameters
@@ -225,6 +227,9 @@ pub struct AnalyticsEventRequest {
   /// Error message if event represents an error
   #[serde(default)]
   pub error_message: Option<String>,
+  /// Optional provider key ID
+  #[serde(default)]
+  pub provider_key_id: Option<i64>,
 }
 
 /// POST /api/v1/analytics/events - Response
@@ -243,6 +248,8 @@ pub struct Filters {
   pub agent_id: Option<i64>,
   /// Provider ID filter applied
   pub provider_id: Option<String>,
+  /// Provider key ID filter applied
+  pub provider_key_id: Option<i64>,
 }
 
 /// Pagination info in response
@@ -610,6 +617,9 @@ pub struct AnalyticsEventWithAgent {
   pub error_code: Option<String>,
   /// Error message if event represents an error
   pub error_message: Option<String>,
+  /// Optional provider key ID
+  #[serde(default)]
+  pub provider_key_id: Option<i64>,
 }
 
 // ============================================================================

--- a/module/iron_control_api/src/routes/analytics/spending.rs
+++ b/module/iron_control_api/src/routes/analytics/spending.rs
@@ -50,6 +50,9 @@ pub async fn get_spending_total(
   if params.provider_id.is_some() {
     query.push_str(" AND provider_id = ?");
   }
+  if params.provider_key_id.is_some() {
+    query.push_str(" AND provider_key_id = ?");
+  }
 
   let mut q = sqlx::query_scalar::<_, i64>(&query)
     .bind(start_ms)
@@ -65,6 +68,9 @@ pub async fn get_spending_total(
   }
   if let Some(ref provider_id) = params.provider_id {
     q = q.bind(provider_id);
+  }
+  if let Some(provider_key_id) = params.provider_key_id {
+    q = q.bind(provider_key_id);
   }
 
   match q.fetch_one(&state.pool).await {
@@ -82,6 +88,7 @@ pub async fn get_spending_total(
           filters: Filters {
             agent_id: params.agent_id,
             provider_id: params.provider_id,
+            provider_key_id: params.provider_key_id,
           },
           calculated_at: Utc::now().to_rfc3339(),
         }),
@@ -301,6 +308,9 @@ pub async fn get_spending_by_provider(
   if params.agent_id.is_some() {
     query.push_str(" AND agent_id = ?");
   }
+  if params.provider_key_id.is_some() {
+    query.push_str(" AND provider_key_id = ?");
+  }
 
   query.push_str(" GROUP BY provider ORDER BY spending_micros DESC");
 
@@ -315,6 +325,9 @@ pub async fn get_spending_by_provider(
 
   if let Some(agent_id) = params.agent_id {
     q = q.bind(agent_id);
+  }
+  if let Some(provider_key_id) = params.provider_key_id {
+    q = q.bind(provider_key_id);
   }
 
   let rows = q.fetch_all(&state.pool).await;
@@ -413,6 +426,9 @@ pub async fn get_spending_avg(
   if params.provider_id.is_some() {
     query.push_str(" AND provider_id = ?");
   }
+  if params.provider_key_id.is_some() {
+    query.push_str(" AND provider_key_id = ?");
+  }
 
   let mut q = sqlx::query_as::<_, (i64, i64, i64, i64)>(&query)
     .bind(start_ms)
@@ -428,6 +444,9 @@ pub async fn get_spending_avg(
   }
   if let Some(ref provider_id) = params.provider_id {
     q = q.bind(provider_id);
+  }
+  if let Some(provider_key_id) = params.provider_key_id {
+    q = q.bind(provider_key_id);
   }
 
   match q.fetch_one(&state.pool).await {
@@ -455,6 +474,7 @@ pub async fn get_spending_avg(
           filters: Filters {
             agent_id: params.agent_id,
             provider_id: params.provider_id,
+            provider_key_id: params.provider_key_id,
           },
           calculated_at: Utc::now().to_rfc3339(),
         }),

--- a/module/iron_control_api/src/routes/analytics/spending.rs
+++ b/module/iron_control_api/src/routes/analytics/spending.rs
@@ -14,9 +14,10 @@ use axum::{
 use chrono::Utc;
 
 use super::shared::{
-  AgentSpending, AnalyticsQuery, AnalyticsState, AvgCostResponse, Filters, Pagination,
-  PaginationQuery, ProviderSpending, ProviderSpendingSummary, SpendingByAgentResponse,
-  SpendingByAgentRow, SpendingByProviderResponse, SpendingSummary, SpendingTotalResponse,
+  compute_change_percent, AgentSpending, AnalyticsQuery, AnalyticsState, AvgCostResponse, Filters,
+  Pagination, PaginationQuery, ProviderSpending, ProviderSpendingSummary,
+  SpendingByAgentResponse, SpendingByAgentRow, SpendingByProviderResponse, SpendingSummary,
+  SpendingTotalComparison, SpendingTotalResponse,
 };
 use crate::jwt_auth::AuthenticatedUser;
 
@@ -54,28 +55,62 @@ pub async fn get_spending_total(
     query.push_str(" AND provider_key_id = ?");
   }
 
-  let mut q = sqlx::query_scalar::<_, i64>(&query)
-    .bind(start_ms)
-    .bind(end_ms);
-
-  // Bind owner_id for non-admins
-  if !is_admin {
-    q = q.bind(&user.0.sub);
+  // Bind time range and all active filters to a spending scalar query.
+  // Defined once to guarantee both the current and previous-period queries
+  // use an identical bind sequence (prevents silent mismatches).
+  macro_rules! bind_spending_filters {
+    ($start:expr, $end:expr) => {{
+      let mut __q = sqlx::query_scalar::<_, i64>(&query)
+        .bind($start)
+        .bind($end);
+      if !is_admin {
+        __q = __q.bind(&user.0.sub);
+      }
+      if let Some(agent_id) = params.agent_id {
+        __q = __q.bind(agent_id);
+      }
+      if let Some(ref provider_id) = params.provider_id {
+        __q = __q.bind(provider_id);
+      }
+      if let Some(provider_key_id) = params.provider_key_id {
+        __q = __q.bind(provider_key_id);
+      }
+      __q
+    }};
   }
 
-  if let Some(agent_id) = params.agent_id {
-    q = q.bind(agent_id);
-  }
-  if let Some(ref provider_id) = params.provider_id {
-    q = q.bind(provider_id);
-  }
-  if let Some(provider_key_id) = params.provider_key_id {
-    q = q.bind(provider_key_id);
-  }
-
-  match q.fetch_one(&state.pool).await {
+  match bind_spending_filters!(start_ms, end_ms)
+    .fetch_one(&state.pool)
+    .await
+  {
     Ok(total_micros) => {
       let total_usd = total_micros as f64 / 1_000_000.0;
+
+      // Compute previous period comparison if requested
+      let previous_period = if params.compare {
+        if let Some((prev_start, prev_end)) = params.period.previous_period_range() {
+          match bind_spending_filters!(prev_start, prev_end)
+            .fetch_one(&state.pool)
+            .await
+          {
+            Ok(prev_micros) => {
+              let prev_usd = prev_micros as f64 / 1_000_000.0;
+              Some(SpendingTotalComparison {
+                total_spend: prev_usd,
+                change_percent: compute_change_percent(total_usd, prev_usd),
+              })
+            }
+            Err(e) => {
+              tracing::warn!("Failed to query previous period spending: {}", e);
+              None
+            }
+          }
+        } else {
+          None // AllTime has no previous period
+        }
+      } else {
+        None
+      };
 
       (
         StatusCode::OK,
@@ -90,6 +125,7 @@ pub async fn get_spending_total(
             provider_id: params.provider_id,
             provider_key_id: params.provider_key_id,
           },
+          previous_period,
           calculated_at: Utc::now().to_rfc3339(),
         }),
       )

--- a/module/iron_control_api/src/routes/analytics/usage.rs
+++ b/module/iron_control_api/src/routes/analytics/usage.rs
@@ -89,6 +89,7 @@ pub async fn get_usage_requests(
           filters: Filters {
             agent_id: params.agent_id,
             provider_id: params.provider_id,
+            provider_key_id: params.provider_key_id,
           },
           calculated_at: Utc::now().to_rfc3339(),
         }),

--- a/module/iron_control_api/src/routes/analytics/usage.rs
+++ b/module/iron_control_api/src/routes/analytics/usage.rs
@@ -13,9 +13,10 @@ use axum::{
 use chrono::Utc;
 
 use super::shared::{
-  AgentTokenUsage, AnalyticsQuery, AnalyticsState, Filters, ModelUsage, ModelUsageResponse,
-  ModelUsageRow, ModelUsageSummary, Pagination, PaginationQuery, RequestUsageResponse,
-  TokenUsageResponse, TokenUsageSummary, TokensByAgentRow,
+  compute_change_percent, AgentTokenUsage, AnalyticsQuery, AnalyticsState, Filters, ModelUsage,
+  ModelUsageResponse, ModelUsageRow, ModelUsageSummary, Pagination, PaginationQuery,
+  RequestUsageComparison, RequestUsageResponse, TokenUsageResponse, TokenUsageSummary,
+  TokensByAgentRow,
 };
 use crate::jwt_auth::AuthenticatedUser;
 
@@ -52,28 +53,69 @@ pub async fn get_usage_requests(
     query.push_str(" AND provider_id = ?");
   }
 
-  let mut q = sqlx::query_as::<_, (i64, i64, i64)>(&query)
-    .bind(start_ms)
-    .bind(end_ms);
-
-  // Bind owner_id for non-admins
-  if !is_admin {
-    q = q.bind(&user.0.sub);
+  // Bind time range and all active filters to a usage query.
+  // Defined once to guarantee both the current and previous-period queries
+  // use an identical bind sequence (prevents silent mismatches).
+  macro_rules! bind_usage_filters {
+    ($start:expr, $end:expr) => {{
+      let mut __q = sqlx::query_as::<_, (i64, i64, i64)>(&query)
+        .bind($start)
+        .bind($end);
+      if !is_admin {
+        __q = __q.bind(&user.0.sub);
+      }
+      if let Some(agent_id) = params.agent_id {
+        __q = __q.bind(agent_id);
+      }
+      if let Some(ref provider_id) = params.provider_id {
+        __q = __q.bind(provider_id);
+      }
+      __q
+    }};
   }
 
-  if let Some(agent_id) = params.agent_id {
-    q = q.bind(agent_id);
-  }
-  if let Some(ref provider_id) = params.provider_id {
-    q = q.bind(provider_id);
-  }
-
-  match q.fetch_one(&state.pool).await {
+  match bind_usage_filters!(start_ms, end_ms)
+    .fetch_one(&state.pool)
+    .await
+  {
     Ok((total, successful, failed)) => {
       let success_rate = if total > 0 {
         (successful as f64 / total as f64) * 100.0
       } else {
         0.0
+      };
+
+      // Compute previous period comparison if requested
+      let previous_period = if params.compare {
+        if let Some((prev_start, prev_end)) = params.period.previous_period_range() {
+          match bind_usage_filters!(prev_start, prev_end)
+            .fetch_one(&state.pool)
+            .await
+          {
+            Ok((prev_total, prev_successful, prev_failed)) => {
+              let prev_success_rate = if prev_total > 0 {
+                (prev_successful as f64 / prev_total as f64) * 100.0
+              } else {
+                0.0
+              };
+              Some(RequestUsageComparison {
+                total_requests: prev_total,
+                successful_requests: prev_successful,
+                failed_requests: prev_failed,
+                success_rate: prev_success_rate,
+                change_percent: compute_change_percent(total as f64, prev_total as f64),
+              })
+            }
+            Err(e) => {
+              tracing::warn!("Failed to query previous period request usage: {}", e);
+              None
+            }
+          }
+        } else {
+          None // AllTime has no previous period
+        }
+      } else {
+        None
       };
 
       (
@@ -91,6 +133,7 @@ pub async fn get_usage_requests(
             provider_id: params.provider_id,
             provider_key_id: params.provider_key_id,
           },
+          previous_period,
           calculated_at: Utc::now().to_rfc3339(),
         }),
       )

--- a/module/iron_control_api/src/routes/budget/handshake.rs
+++ b/module/iron_control_api/src/routes/budget/handshake.rs
@@ -302,6 +302,8 @@ pub async fn handshake(
   let provider_type = match request.provider.as_str() {
     "openai" => ProviderType::OpenAI,
     "anthropic" => ProviderType::Anthropic,
+    "gemini" => ProviderType::Gemini,
+    "xai" => ProviderType::XAI,
     _ => {
       return (
         StatusCode::BAD_REQUEST,

--- a/module/iron_control_api/src/routes/budget/handshake.rs
+++ b/module/iron_control_api/src/routes/budget/handshake.rs
@@ -320,89 +320,86 @@ pub async fn handshake(
   //   None:     use the key assigned to this agent in the agents table;
   //             if none is assigned, reject with NO_PROVIDER_ASSIGNED
   //             (agent_id == 1 + IRON_ALLOW_DEV_KEYS env var permits auto-creation for dev)
-  let key_id_pre = match request.provider_key_id {
-    Some(id) => {
-      // Ownership check: key must belong to agent's owner
-      match state.provider_key_storage.get_key_metadata(id).await {
-        Ok(meta) if meta.user_id == owner_for_key => id,
-        Ok(_) => {
-          return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "error": "UNAUTHORIZED_KEY_ACCESS" })),
-          )
-            .into_response();
-        }
-        Err(iron_token_manager::error::TokenError::NotFound) => {
-          return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "Provider key not found" })),
-          )
-            .into_response();
-        }
-        Err(err) => {
-          tracing::error!("Database error fetching provider key metadata: {}", err);
-          return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": "Key storage unavailable" })),
-          )
-            .into_response();
-        }
+  let key_id_pre = if let Some(id) = request.provider_key_id {
+    // Ownership check: key must belong to agent's owner
+    match state.provider_key_storage.get_key_metadata(id).await {
+      Ok(meta) if meta.user_id == owner_for_key => id,
+      Ok(_) => {
+        return (
+          StatusCode::FORBIDDEN,
+          Json(serde_json::json!({ "error": "UNAUTHORIZED_KEY_ACCESS" })),
+        )
+          .into_response();
+      }
+      Err(iron_token_manager::error::TokenError::NotFound) => {
+        return (
+          StatusCode::NOT_FOUND,
+          Json(serde_json::json!({ "error": "Provider key not found" })),
+        )
+          .into_response();
+      }
+      Err(err) => {
+        tracing::error!("Database error fetching provider key metadata: {}", err);
+        return (
+          StatusCode::INTERNAL_SERVER_ERROR,
+          Json(serde_json::json!({ "error": "Key storage unavailable" })),
+        )
+          .into_response();
       }
     }
-    None => {
-      // Use the provider key assigned to this agent
-      let assigned_key_id: Option<i64> = match sqlx::query_scalar(
-        "SELECT provider_key_id FROM agents WHERE id = ?",
-      )
-      .bind(agent_id)
-      .fetch_one(&state.db_pool)
-      .await
-      {
-        Ok(id) => id,
-        Err(err) => {
-          tracing::error!("Database error fetching agent provider_key_id: {}", err);
+  } else {
+    // Use the provider key assigned to this agent
+    let assigned_key_id: Option<i64> = match sqlx::query_scalar(
+      "SELECT provider_key_id FROM agents WHERE id = ?",
+    )
+    .bind(agent_id)
+    .fetch_one(&state.db_pool)
+    .await
+    {
+      Ok(id) => id,
+      Err(err) => {
+        tracing::error!("Database error fetching agent provider_key_id: {}", err);
+        return (
+          StatusCode::INTERNAL_SERVER_ERROR,
+          Json(serde_json::json!({ "error": "Database error" })),
+        )
+          .into_response();
+      }
+    };
+
+    match assigned_key_id {
+      Some(id) => id,
+      None => {
+        // No key assigned; allow auto-creation only for agent_1 when dev mode is explicitly enabled
+        if agent_id == 1 && std::env::var("IRON_ALLOW_DEV_KEYS").is_ok() {
+          tracing::warn!(
+            "IRON_ALLOW_DEV_KEYS: auto-creating dev provider key for agent_1 (provider={})",
+            provider_type
+          );
+          match create_dev_provider_key_for_agent1(&state, provider_type, &owner_for_key).await {
+            Ok(new_id) => {
+              let _ = sqlx::query("UPDATE agents SET provider_key_id = ? WHERE id = ?")
+                .bind(new_id)
+                .bind(agent_id)
+                .execute(&state.db_pool)
+                .await;
+              new_id
+            }
+            Err(e) => {
+              tracing::error!("Failed to auto-create provider key: {}", e);
+              return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({ "error": "NO_PROVIDER_ASSIGNED" })),
+              )
+                .into_response();
+            }
+          }
+        } else {
           return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": "Database error" })),
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "NO_PROVIDER_ASSIGNED" })),
           )
             .into_response();
-        }
-      };
-
-      match assigned_key_id {
-        Some(id) => id,
-        None => {
-          // No key assigned; allow auto-creation only for agent_1 when dev mode is explicitly enabled
-          if agent_id == 1 && std::env::var("IRON_ALLOW_DEV_KEYS").is_ok() {
-            tracing::warn!(
-              "IRON_ALLOW_DEV_KEYS: auto-creating dev provider key for agent_1 (provider={})",
-              provider_type
-            );
-            match create_dev_provider_key_for_agent1(&state, provider_type, &owner_for_key).await {
-              Ok(new_id) => {
-                let _ = sqlx::query("UPDATE agents SET provider_key_id = ? WHERE id = ?")
-                  .bind(new_id)
-                  .bind(agent_id)
-                  .execute(&state.db_pool)
-                  .await;
-                new_id
-              }
-              Err(e) => {
-                tracing::error!("Failed to auto-create provider key: {}", e);
-                return (
-                  StatusCode::FORBIDDEN,
-                  Json(serde_json::json!({ "error": "NO_PROVIDER_ASSIGNED" })),
-                )
-                  .into_response();
-              }
-            }
-          } else {
-            return (
-              StatusCode::FORBIDDEN,
-              Json(serde_json::json!({ "error": "NO_PROVIDER_ASSIGNED" })),
-            )
-              .into_response();
-          }
         }
       }
     }
@@ -423,42 +420,48 @@ pub async fn handshake(
     .requested_budget
     .unwrap_or(HandshakeRequest::DEFAULT_HANDSHAKE_BUDGET);
 
-  let budget_to_grant = match state
+  let reservation = match state
     .agent_budget_manager
-    .check_and_reserve_budget(agent_id, budget_requested)
+    .reserve_budget_with_limits(agent_id, Some(key_id_pre), budget_requested)
     .await
   {
-    Ok(granted) if granted > 0 => granted,
-    Ok(_) => {
-      // Insufficient budget or agent doesnt exist
-      // Fetch budget details for error response
-      let agent_budget = state
-        .agent_budget_manager
-        .get_budget_status(agent_id)
-        .await
-        .ok()
-        .flatten();
-
-      return (
-        StatusCode::FORBIDDEN,
-        Json(serde_json::json!(
-        {
-          "error": "Budget limit exceeded",
-          "total_allocated": agent_budget.as_ref().map( | b | b.total_allocated ),
-          "total_spent": agent_budget.as_ref().map( | b | b.total_spent ),
-          "budget_remaining": agent_budget.as_ref().map( | b | b.budget_remaining )
-        } )),
-      )
-        .into_response();
-    }
+    Ok(r) => r,
     Err(err) => {
-      tracing::error!("Database error checking and reserving budget: {}", err);
+      tracing::error!("Database error reserving budget: {}", err);
       return (
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(serde_json::json!({ "error": "Budget service unavailable" })),
       )
         .into_response();
     }
+  };
+
+  let budget_to_grant = if reservation.blocked_by.is_none() && reservation.granted > 0 {
+    reservation.granted
+  } else {
+    let error_msg = match reservation.blocked_by {
+      Some(iron_token_manager::BlockedBy::AgentSpendingCap) => "Agent spending limit exceeded",
+      Some(iron_token_manager::BlockedBy::ProviderKeyCap) => "Provider key spending cap exceeded",
+      Some(iron_token_manager::BlockedBy::InsufficientBudget) | None => "Budget limit exceeded",
+    };
+
+    let agent_budget = state
+      .agent_budget_manager
+      .get_budget_status(agent_id)
+      .await
+      .ok()
+      .flatten();
+
+    return (
+      StatusCode::FORBIDDEN,
+      Json(serde_json::json!({
+        "error": error_msg,
+        "total_allocated": agent_budget.as_ref().map(|b| b.total_allocated),
+        "total_spent": agent_budget.as_ref().map(|b| b.total_spent),
+        "budget_remaining": agent_budget.as_ref().map(|b| b.budget_remaining)
+      })),
+    )
+      .into_response();
   };
 
   let key_id = key_id_pre;
@@ -551,7 +554,7 @@ pub async fn handshake(
 
   if let Err(err) = state
     .lease_manager
-    .create_lease(&lease_id, agent_id, agent_id, budget_to_grant, None)
+    .create_lease(&lease_id, agent_id, agent_id, budget_to_grant, None, Some(key_id))
     .await
   {
     tracing::error!("Database error creating lease: {}", err);
@@ -589,13 +592,7 @@ pub async fn handshake(
     "Budget lease granted, deducted from usage_limits"
   );
 
-  let budget_remaining_after = state
-    .agent_budget_manager
-    .get_budget_status(agent_id)
-    .await
-    .ok()
-    .flatten()
-    .map_or(0, |b| b.budget_remaining);
+  let budget_remaining_after = reservation.agent_budget_remaining;
 
   // Return successful handshake response
   (

--- a/module/iron_control_api/src/routes/budget/refresh.rs
+++ b/module/iron_control_api/src/routes/budget/refresh.rs
@@ -277,26 +277,12 @@ pub async fn refresh_budget(
   // endpoint does this correctly (handshake.rs:256-258), refresh endpoint must match.
 
   // Atomically check and reserve budget for new lease
-  let budget_granted = match state
+  let reservation = match state
     .agent_budget_manager
-    .check_and_reserve_budget(lease.agent_id, requested_budget)
+    .reserve_budget_with_limits(lease.agent_id, lease.provider_key_id, requested_budget)
     .await
   {
-    Ok(granted) if granted > 0 => granted,
-    Ok(_) => {
-      // Insufficient budget - deny request
-      return (
-        StatusCode::OK,
-        Json(BudgetRefreshResponse {
-          status: "denied".to_string(),
-          budget_granted: None,
-          budget_remaining: agent_budget.budget_remaining,
-          lease_id: None,
-          reason: Some("insufficient_budget".to_string()),
-        }),
-      )
-        .into_response();
-    }
+    Ok(r) => r,
     Err(err) => {
       tracing::error!("Database error checking and reserving budget: {}", err);
       return (
@@ -305,6 +291,27 @@ pub async fn refresh_budget(
       )
         .into_response();
     }
+  };
+
+  let budget_granted = if reservation.blocked_by.is_none() && reservation.granted > 0 {
+    reservation.granted
+  } else {
+    let reason = match reservation.blocked_by {
+      Some(iron_token_manager::BlockedBy::AgentSpendingCap) => "agent_spending_cap_exceeded",
+      Some(iron_token_manager::BlockedBy::ProviderKeyCap) => "provider_key_cap_exceeded",
+      Some(iron_token_manager::BlockedBy::InsufficientBudget) | None => "insufficient_budget",
+    };
+    return (
+      StatusCode::OK,
+      Json(BudgetRefreshResponse {
+        status: "denied".to_string(),
+        budget_granted: None,
+        budget_remaining: agent_budget.budget_remaining,
+        lease_id: None,
+        reason: Some(reason.to_string()),
+      }),
+    )
+      .into_response();
   };
 
   // Create new lease with granted budget
@@ -318,6 +325,7 @@ pub async fn refresh_budget(
       lease.budget_id,
       budget_granted,
       None,
+      lease.provider_key_id,
     )
     .await
   {

--- a/module/iron_control_api/src/routes/budget/usage.rs
+++ b/module/iron_control_api/src/routes/budget/usage.rs
@@ -523,17 +523,16 @@ pub async fn return_budget(
   if returned > 0 {
     if let Err(err) = state
       .agent_budget_manager
-      .restore_reserved_budget(lease.agent_id, returned)
+      .restore_budget_with_limits(lease.agent_id, lease.provider_key_id, returned)
       .await
     {
       tracing::error!("Database error restoring agent budget: {}", err);
-      // Continue - lease is closed, log the error but don't fail the return
     } else {
       tracing::info!(
         lease_id = %request.lease_id,
         agent_id = lease.agent_id,
         returned_microdollars = %returned,
-        "Budget restored to agent_budgets"
+        "Budget restored to agent_budgets and provider key"
       );
     }
   }

--- a/module/iron_control_api/src/routes/providers.rs
+++ b/module/iron_control_api/src/routes/providers.rs
@@ -125,10 +125,14 @@ impl CreateProviderKeyRequest {
   /// or too long, or optional fields exceed length limits.
   pub fn validate(&self) -> Result<(), ValidationError> {
     // Validate provider type
-    if self.provider != "openai" && self.provider != "anthropic" {
+    if self.provider != "openai"
+      && self.provider != "anthropic"
+      && self.provider != "gemini"
+      && self.provider != "xai"
+    {
       return Err(ValidationError::InvalidFormat {
         field: "provider".to_owned(),
-        expected: "'openai' or 'anthropic'".to_owned(),
+        expected: "'openai', 'anthropic', 'gemini', or 'xai'".to_owned(),
       });
     }
 
@@ -339,6 +343,8 @@ pub async fn create_provider_key(
   let provider = match request.provider.as_str() {
     "openai" => ProviderType::OpenAI,
     "anthropic" => ProviderType::Anthropic,
+    "gemini" => ProviderType::Gemini,
+    "xai" => ProviderType::XAI,
     _ => return Err(ApiError::BadRequest("Invalid provider type".into())),
   };
 

--- a/module/iron_control_api/src/routes/providers.rs
+++ b/module/iron_control_api/src/routes/providers.rs
@@ -21,7 +21,7 @@ use axum::{
   http::StatusCode,
   response::{IntoResponse, Json},
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::Deserializer, Deserialize, Serialize};
 use sqlx::sqlite::SqlitePoolOptions;
 
 use crate::{
@@ -191,6 +191,7 @@ impl CreateProviderKeyRequest {
 
 /// Update provider key request
 #[derive(Debug, Deserialize)]
+#[allow(clippy::option_option)] // Three-state semantics for spending_cap_usd
 pub struct UpdateProviderKeyRequest {
   /// Updated base URL override
   pub base_url: Option<String>,
@@ -199,7 +200,29 @@ pub struct UpdateProviderKeyRequest {
   /// Enable or disable this key
   pub is_enabled: Option<bool>,
   /// Spending cap in USD (None = don't change, Some(None) = remove cap, Some(Some(x)) = set cap)
+  ///
+  /// JSON mapping:
+  /// - field absent → `None` (don't change)
+  /// - `"spending_cap_usd": null` → `Some(None)` (remove cap / unlimited)
+  /// - `"spending_cap_usd": 10.0` → `Some(Some(10.0))` (set cap)
+  #[serde(default, deserialize_with = "deserialize_nullable_f64")]
   pub spending_cap_usd: Option<Option<f64>>,
+}
+
+/// Deserialize a JSON field into `Option<Option<f64>>` with three-state semantics.
+///
+/// - Field absent (handled by `#[serde(default)]`) → `None`
+/// - Field present as `null` → `Some(None)`
+/// - Field present as number → `Some(Some(value))`
+#[allow(clippy::option_option)] // Three-state semantics: absent vs null vs value
+fn deserialize_nullable_f64<'de, D>(deserializer: D) -> Result<Option<Option<f64>>, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  // If this function is called, the field was present in JSON.
+  // Deserialize its value: null becomes None, number becomes Some(x).
+  let value: Option<f64> = Option::deserialize(deserializer)?;
+  Ok(Some(value))
 }
 
 /// Provider key response (never contains plaintext API key)
@@ -292,6 +315,10 @@ fn check_manage_provider_keys(role_str: &str) -> Result<(), crate::error::ApiErr
 /// POST /api/providers
 ///
 /// Create new AI provider key
+///
+/// # Errors
+///
+/// Returns `ApiError` if encryption fails, database insert fails, or request validation fails.
 pub async fn create_provider_key(
   State(state): State<ProvidersState>,
   AuthenticatedUser(claims): AuthenticatedUser,

--- a/module/iron_control_api/tests/analytics_ic_token_test.rs
+++ b/module/iron_control_api/tests/analytics_ic_token_test.rs
@@ -65,6 +65,7 @@ async fn setup_analytics_db() -> SqlitePool {
       provider_id TEXT,
       error_code TEXT,
       error_message TEXT,
+      provider_key_id INTEGER,
       received_at INTEGER NOT NULL,
       UNIQUE(agent_id, event_id)
     )",

--- a/module/iron_control_api/tests/budget_corner_cases.rs
+++ b/module/iron_control_api/tests/budget_corner_cases.rs
@@ -280,7 +280,7 @@ async fn test_report_usage_negative_tokens() {
   seed_agent_with_budget(&pool, 111, 100_000_000).await;
 
   let state = create_test_budget_state(pool.clone()).await;
-  let ic_token = create_ic_token(&pool, 1, &state.ic_token_manager).await;
+  let ic_token = create_ic_token(&pool, 111, &state.ic_token_manager).await;
 
   // Create lease first
   let app1 = create_budget_router(state.clone()).await;
@@ -371,7 +371,7 @@ async fn test_report_usage_negative_cost() {
   seed_agent_with_budget(&pool, 112, 100_000_000).await;
 
   let state = create_test_budget_state(pool.clone()).await;
-  let ic_token = create_ic_token(&pool, 1, &state.ic_token_manager).await;
+  let ic_token = create_ic_token(&pool, 112, &state.ic_token_manager).await;
 
   // Create lease first
   let app1 = create_budget_router(state.clone()).await;
@@ -510,7 +510,7 @@ async fn test_report_usage_zero_cost_cached_response() {
   seed_agent_with_budget(&pool, 113, 100_000_000).await;
 
   let state = create_test_budget_state(pool.clone()).await;
-  let ic_token = create_ic_token(&pool, 1, &state.ic_token_manager).await;
+  let ic_token = create_ic_token(&pool, 113, &state.ic_token_manager).await;
 
   // Create lease first
   let app1 = create_budget_router(state.clone()).await;
@@ -1160,7 +1160,7 @@ async fn test_cost_exactly_equals_remaining_budget() {
   let lease_id = "lease_exact_boundary_test";
   state
     .lease_manager
-    .create_lease(lease_id, 120, 120, 10_000_000, None)
+    .create_lease(lease_id, 120, 120, 10_000_000, None, None)
     .await
     .expect("LOUD FAILURE: Should create lease");
 
@@ -1367,7 +1367,7 @@ async fn test_report_usage_integer_overflow_tokens() {
   let lease_id = "lease_tokens_overflow_test";
   state
     .lease_manager
-    .create_lease(lease_id, 121, 121, 10_000_000, None)
+    .create_lease(lease_id, 121, 121, 10_000_000, None, None)
     .await
     .expect("LOUD FAILURE: Should create lease");
 
@@ -1443,7 +1443,7 @@ async fn test_idempotency_duplicate_event_id() {
   let budget_granted = 10_000_000i64; // $10 USD
   state
     .lease_manager
-    .create_lease(lease_id, agent_id, agent_id, budget_granted, None)
+    .create_lease(lease_id, agent_id, agent_id, budget_granted, None, None)
     .await
     .expect("LOUD FAILURE: Should create lease");
 

--- a/module/iron_control_api/tests/budget_database_state.rs
+++ b/module/iron_control_api/tests/budget_database_state.rs
@@ -566,7 +566,7 @@ async fn test_report_usage_on_expired_lease() {
 
   state
     .lease_manager
-    .create_lease(lease_id, 116, 116, 10_000_000, Some(one_hour_ago)) // $10
+    .create_lease(lease_id, 116, 116, 10_000_000, Some(one_hour_ago), None) // $10
     .await
     .unwrap();
 
@@ -725,7 +725,7 @@ async fn test_report_usage_exceeding_lease_budget() {
   let lease_id = "lease_budget_test";
   state
     .lease_manager
-    .create_lease(lease_id, 117, 117, 1_000_000, None) // $1.00
+    .create_lease(lease_id, 117, 117, 1_000_000, None, None) // $1.00
     .await
     .unwrap();
 
@@ -919,7 +919,7 @@ async fn test_refresh_with_insufficient_agent_budget() {
   let lease_id = "lease_refresh_test";
   state
     .lease_manager
-    .create_lease(lease_id, 118, 118, 10_000_000, None) // $10
+    .create_lease(lease_id, 118, 118, 10_000_000, None, None) // $10
     .await
     .unwrap();
 

--- a/module/iron_control_api/tests/common/budget.rs
+++ b/module/iron_control_api/tests/common/budget.rs
@@ -201,36 +201,8 @@ pub async fn seed_agent_with_budget(pool: &SqlitePool, agent_id: i64, budget_mic
   .await
   .unwrap();
 
-  // Insert agent with owner_id
-  sqlx::query(
-    "INSERT OR IGNORE INTO agents (id, name, providers, created_at, owner_id) VALUES (?, ?, ?, ?, ?)"
-  )
-  .bind( agent_id )
-  .bind( format!( "test_agent_{agent_id}" ) )
-  .bind( serde_json::to_string( &vec![ "openai" ] ).unwrap() )
-  .bind( now_ms )
-  .bind( "test_user" )
-  .execute( pool )
-  .await
-  .unwrap();
-
-  // Insert agent budget (using microdollars)
-  sqlx::query(
-    "INSERT OR IGNORE INTO agent_budgets (agent_id, total_allocated, total_spent, budget_remaining, created_at, updated_at)
-     VALUES (?, ?, 0, ?, ?, ?)"
-  )
-  .bind( agent_id )
-  .bind( budget_microdollars )
-  .bind( budget_microdollars )
-  .bind( now_ms )
-  .bind( now_ms )
-  .execute( pool )
-  .await
-  .unwrap();
-
-  // Insert provider key
+  // Insert provider key first (agent references it via FK)
   // Use unique provider key ID based on agent_id to avoid conflicts between tests
-  // Create real encrypted provider key for testing
   let test_provider_key = format!("sk-test_key_for_agent_{agent_id}");
   let provider_key_master: [u8; 32] = [42u8; 32]; // Test master key (must match create_test_budget_state)
   let crypto_service =
@@ -250,6 +222,34 @@ pub async fn seed_agent_with_budget(pool: &SqlitePool, agent_id: i64, budget_mic
   .bind( 1 )
   .bind( now_ms )
   .bind( "test_user" )
+  .execute( pool )
+  .await
+  .unwrap();
+
+  // Insert agent with owner_id and provider_key_id
+  sqlx::query(
+    "INSERT OR IGNORE INTO agents (id, name, providers, created_at, owner_id, provider_key_id) VALUES (?, ?, ?, ?, ?, ?)"
+  )
+  .bind( agent_id )
+  .bind( format!( "test_agent_{agent_id}" ) )
+  .bind( serde_json::to_string( &vec![ "openai" ] ).unwrap() )
+  .bind( now_ms )
+  .bind( "test_user" )
+  .bind( agent_id * 1000 )
+  .execute( pool )
+  .await
+  .unwrap();
+
+  // Insert agent budget (using microdollars)
+  sqlx::query(
+    "INSERT OR IGNORE INTO agent_budgets (agent_id, total_allocated, total_spent, budget_remaining, created_at, updated_at)
+     VALUES (?, ?, 0, ?, ?, ?)"
+  )
+  .bind( agent_id )
+  .bind( budget_microdollars )
+  .bind( budget_microdollars )
+  .bind( now_ms )
+  .bind( now_ms )
   .execute( pool )
   .await
   .unwrap();

--- a/module/iron_control_api/tests/protocol_005_enforcement_simple.rs
+++ b/module/iron_control_api/tests/protocol_005_enforcement_simple.rs
@@ -75,11 +75,21 @@ async fn test_database_constraints_enforce_agent_budget_relationship() {
      Without this, leases could reference non-existent budgets."
   );
 
-  // Conclusion: Database enforces agent-budget-lease relationship
+  // Assert: provider_key_id foreign key exists (added by migration 026)
+  let has_provider_key_fk = foreign_keys
+    .iter()
+    .any(|(from, table, _to)| from == "provider_key_id" && table == "ai_provider_keys");
+  assert!(
+    has_provider_key_fk,
+    "budget_leases MUST have foreign key on provider_key_id → ai_provider_keys(id). \
+     Without this, leases could reference non-existent provider keys."
+  );
+
+  // Conclusion: Database enforces agent-budget-lease-provider relationship
   assert_eq!(
     foreign_keys.len(),
-    2,
-    "budget_leases should have exactly 2 foreign keys (agent_id, budget_id)"
+    3,
+    "budget_leases should have exactly 3 foreign keys (agent_id, budget_id, provider_key_id)"
   );
 }
 

--- a/module/iron_control_api/tests/protocol_005_rollback_verification.rs
+++ b/module/iron_control_api/tests/protocol_005_rollback_verification.rs
@@ -225,7 +225,7 @@ async fn test_protocol_005_budget_flow_works() {
   let budget_id = agent_id; // budget_id = agent_id (1:1 relationship)
 
   lease_manager
-    .create_lease(&lease_id, agent_id, budget_id, 10_000_000, None)
+    .create_lease(&lease_id, agent_id, budget_id, 10_000_000, None, None)
     .await
     .unwrap();
 

--- a/module/iron_control_api/tests/readme.md
+++ b/module/iron_control_api/tests/readme.md
@@ -47,6 +47,7 @@ tests/
 │   └── readme.md           # Manual testing procedures (416 lines, covers FR-7/8/9)
 ├── api_test.rs             # API integration tests
 ├── integration_tests.rs    # Full integration test suite
+├── spending_limits.rs      # Per-provider spending limit enforcement tests (11 tests)
 └── rbac.rs                 # RBAC middleware tests
 ```
 
@@ -86,12 +87,13 @@ tests/
 | `agent_provider_key_tests.rs` | Test provider API key retrieval endpoint | Key fetch scenarios → Retrieval validation | Feature 014 provider key tests | NOT budget (budget_*), NOT auth (auth/), NOT tokens (tokens/) |
 | `ip_token_e2e_test.rs` | Test end-to-end IP Token encryption flow across server/client boundary | Server response → Client plaintext key | NOT HTTP integration (integration_tests.rs), NOT budget flow (budget_*), NOT auth (auth/) |
 | `test_no_url_redirect.rs` | Validate url_redirect middleware deletion | Source code → NEGATIVE ACCEPTANCE validation | NOT endpoint tests (tokens/, auth/), NOT integration (integration_tests.rs), NOT manual (manual/) |
+| `spending_limits.rs` | Test per-IC-key and per-IP-key spending limit enforcement (unified reservation) | Spending cap scenarios → Atomic enforcement validation | NOT budget accounting (budget_database_state.rs), NOT budget flow (budget_routes.rs), NOT concurrency (budget_concurrency.rs), NOT auth (auth/) |
 | `test_cors_configuration.rs` | Validate CORS configuration via environment variable | Source code → Environment variable enforcement | NOT endpoint tests (tokens/, auth/), NOT integration (integration_tests.rs), NOT manual (manual/) |
 | `test_server_port_configuration.rs` | Validate server port via environment variable | Source code → Environment variable enforcement | NOT endpoint tests (tokens/, auth/), NOT integration (integration_tests.rs), NOT manual (manual/) |
 
 ## Test Coverage Summary
 
-**Total Tests:** 504 (499 passing, 5 failing infrastructure bug reproducers for issue-003, 8 implementation bugs fixed, +26 Protocol 005 tests, +120 Migration tests)
+**Total Tests:** 549 (544 passing, 5 failing infrastructure bug reproducers for issue-003, 8 implementation bugs fixed, +26 Protocol 005 tests, +120 Migration tests, +11 Spending Limits tests)
 
 **Phase 1 Security Additions** (2025-12-06):
 - **issue-001:** 3 DoS protection bug reproducer tests (unbounded string inputs)
@@ -193,6 +195,22 @@ tests/
   - `total_allocated = total_spent + budget_remaining` verified after handshake, report, and refresh
 - **Migration Complete:** 499 tests → **IC Token Runtime Validation Complete:** 538 tests (+39 tests, +8%)
 - **Status:** All IC Token runtime validation tests passing, HMAC secret redacted, rate limiting enforced
+
+**Per-Provider Spending Limits** (2026-03-09):
+- **spending_limits.rs:** 11 integration tests for unified per-IC-key and per-IP-key spending cap enforcement
+  - IC-key (agent) spending cap blocks handshake when exceeded → `BlockedBy::AgentSpendingCap`
+  - IP-key (provider key) spending cap blocks handshake when exceeded → `BlockedBy::ProviderKeyCap`
+  - Sequential handshakes exhaust IC-key cap (grants until cap hit, then blocked)
+  - Sequential handshakes exhaust IP-key cap (grants until cap hit, then blocked)
+  - Budget return reverses both IC-key and IP-key spending atomically
+  - NULL spending cap = unlimited (no enforcement)
+  - Lease stores correct `provider_key_id` for attribution
+  - Multiple agents sharing same IP key — cap applies across all agents
+  - Agent cap isolation — one agent's cap doesn't affect other agents
+  - Concurrent handshakes respect IC-key cap (exactly N succeed where N = cap / amount)
+  - Insufficient agent budget blocks before cap checks
+- **IC Token Runtime Validation Complete:** 538 tests → **Spending Limits Complete:** 549 tests (+11 tests, +2%)
+- **Status:** All spending limit tests passing, atomic single-transaction enforcement verified
 
 ### By Protocol and Functional Requirement
 
@@ -368,8 +386,8 @@ Follow bug-fixing workflow (code_design.rulebook.md):
 
 ## Verification
 
-Last verified: 2026-02-18 (IC Token Runtime Validation Complete — PR #44)
-- ✅ 538 tests passing (all 8 implementation bugs fixed + 39 new IC Token tests)
+Last verified: 2026-03-09 (Per-Provider Spending Limits Complete)
+- ✅ 549 tests passing (all 8 implementation bugs fixed + 39 IC Token tests + 11 spending limit tests)
 - ✅ 0 clippy warnings
 - ✅ All Phase 1-5 tests passing (Security, Corner Cases, API Contract, Edge Cases, Additional Coverage)
 - ✅ All doc tests passing
@@ -404,3 +422,9 @@ Last verified: 2026-02-18 (IC Token Runtime Validation Complete — PR #44)
   - ✅ validate_ic_token_for_endpoint all code paths covered (GAP-2)
   - ✅ Concurrent validation + regeneration: no deadlock (H5)
   - ✅ Analytics endpoint IC Token rotation tested (M5)
+- ✅ Per-provider spending limits complete:
+  - ✅ IC-key (agent) spending cap enforcement via `reserve_budget_with_limits`
+  - ✅ IP-key (provider key) spending cap enforcement in same atomic transaction
+  - ✅ Budget return reverses both caps atomically via `restore_budget_with_limits`
+  - ✅ NULL cap = unlimited, concurrent races respect caps, lease attribution verified
+  - ✅ Multi-agent shared key isolation, agent cap isolation across agents

--- a/module/iron_control_api/tests/spending_limits.rs
+++ b/module/iron_control_api/tests/spending_limits.rs
@@ -1,0 +1,531 @@
+//! Per-IC-key and Per-IP-key spending limit integration tests
+//!
+//! Verifies that `reserve_budget_with_limits` enforces both agent (IC-key) and
+//! provider key (IP-key) spending caps atomically, and that `restore_budget_with_limits`
+//! correctly reverses spending on both sides.
+//!
+//! # Test Matrix
+//!
+//! | Test Case | Scenario | Expected |
+//! |-----------|----------|----------|
+//! | `test_ic_key_cap_blocks_handshake` | Agent cap exceeded | `BlockedBy::AgentSpendingCap` |
+//! | `test_ip_key_cap_blocks_handshake` | Provider key cap exceeded | `BlockedBy::ProviderKeyCap` |
+//! | `test_sequential_handshakes_exhaust_ic_cap` | Multiple reserves hit IC cap | Last blocked |
+//! | `test_sequential_handshakes_exhaust_ip_cap` | Multiple reserves hit IP cap | Last blocked |
+//! | `test_budget_return_reverses_both_caps` | Restore reverses IC + IP spending | Spending decremented |
+//! | `test_null_cap_means_unlimited` | No cap set | Unlimited spending allowed |
+//! | `test_lease_stores_provider_key_id` | Lease attribution | `provider_key_id` persisted |
+//! | `test_multiple_agents_share_ip_key_cap` | Shared key across agents | Cap shared |
+//! | `test_agent_cap_isolated_between_agents` | Separate agents | Caps independent |
+//! | `test_concurrent_handshakes_respect_cap` | Race condition | Exactly N succeed |
+//! | `test_refresh_denied_when_cap_exhausted` | Cap exhausted before refresh | Blocked |
+//!
+//! # Authority
+//! - Plan: Unified Per-IC-Key and Per-IP-Key Spending Limits (Tasks 003 + 004)
+
+mod common;
+
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+
+use iron_token_manager::{
+  agent_budget::AgentBudgetManager,
+  lease_manager::LeaseManager,
+  provider_key_storage::ProviderKeyStorage,
+  BlockedBy, SpendingCap,
+};
+
+use common::budget::setup_test_db;
+
+/// Seed a minimal agent with budget (no provider key assignment — tests manage keys directly)
+async fn seed_agent_budget(pool: &SqlitePool, agent_id: i64, budget_microdollars: i64) {
+  let now_ms = chrono::Utc::now().timestamp_millis();
+
+  sqlx::query(
+    "INSERT OR IGNORE INTO users (id, username, password_hash, email, role, is_active, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)",
+  )
+  .bind("test_user")
+  .bind("test_username")
+  .bind("$2b$12$test_password_hash")
+  .bind("test@example.com")
+  .bind("admin")
+  .bind(1)
+  .bind(now_ms)
+  .execute(pool)
+  .await
+  .unwrap();
+
+  sqlx::query(
+    "INSERT OR IGNORE INTO agents (id, name, providers, created_at, owner_id) VALUES (?, ?, '[]', ?, ?)",
+  )
+  .bind(agent_id)
+  .bind(format!("test_agent_{agent_id}"))
+  .bind(now_ms)
+  .bind("test_user")
+  .execute(pool)
+  .await
+  .unwrap();
+
+  sqlx::query(
+    "INSERT OR IGNORE INTO agent_budgets (agent_id, total_allocated, total_spent, budget_remaining, created_at, updated_at)
+     VALUES (?, ?, 0, ?, ?, ?)",
+  )
+  .bind(agent_id)
+  .bind(budget_microdollars)
+  .bind(budget_microdollars)
+  .bind(now_ms)
+  .bind(now_ms)
+  .execute(pool)
+  .await
+  .unwrap();
+}
+
+/// Seed a provider key with optional spending cap
+async fn seed_provider_key(
+  pool: &SqlitePool,
+  key_id: i64,
+  cap_microdollars: Option<i64>,
+) {
+  let now_ms = chrono::Utc::now().timestamp_millis();
+
+  sqlx::query(
+    "INSERT OR IGNORE INTO ai_provider_keys (id, provider, encrypted_api_key, encryption_nonce, is_enabled, created_at, user_id, spending_cap_microdollars)
+     VALUES (?, 'openai', 'enc_key', 'nonce', 1, ?, 'test_user', ?)",
+  )
+  .bind(key_id)
+  .bind(now_ms)
+  .bind(cap_microdollars)
+  .execute(pool)
+  .await
+  .unwrap();
+}
+
+// ─── Test 1: IC-key (agent) spending cap blocks reservation ───────────────────
+
+#[tokio::test]
+async fn test_ic_key_cap_blocks_handshake() {
+  let pool = setup_test_db().await;
+  let agent_id = 200i64;
+  let key_id = 200_000i64;
+
+  seed_agent_budget(&pool, agent_id, 50_000_000).await; // $50 budget
+  seed_provider_key(&pool, key_id, None).await; // No IP-key cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+
+  // Set IC-key cap to $5
+  mgr
+    .set_spending_cap(agent_id, SpendingCap::Limited(5_000_000))
+    .await
+    .expect("LOUD FAILURE: Should set spending cap");
+
+  // Try to reserve $10 — exceeds $5 cap
+  let result = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .expect("LOUD FAILURE: Should return result, not DB error");
+
+  assert_eq!(
+    result.blocked_by,
+    Some(BlockedBy::AgentSpendingCap),
+    "LOUD FAILURE: Should be blocked by agent spending cap"
+  );
+  assert_eq!(result.granted, 0);
+}
+
+// ─── Test 2: IP-key (provider key) spending cap blocks reservation ────────────
+
+#[tokio::test]
+async fn test_ip_key_cap_blocks_handshake() {
+  let pool = setup_test_db().await;
+  let agent_id = 201i64;
+  let key_id = 201_000i64;
+
+  seed_agent_budget(&pool, agent_id, 50_000_000).await;
+  seed_provider_key(&pool, key_id, Some(3_000_000)).await; // $3 IP-key cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+
+  // No IC-key cap, but IP-key cap is $3 — try to reserve $10
+  let result = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .expect("LOUD FAILURE: Should return result, not DB error");
+
+  assert_eq!(
+    result.blocked_by,
+    Some(BlockedBy::ProviderKeyCap),
+    "LOUD FAILURE: Should be blocked by provider key spending cap"
+  );
+  assert_eq!(result.granted, 0);
+}
+
+// ─── Test 3: Sequential handshakes exhaust IC-key cap ─────────────────────────
+
+#[tokio::test]
+async fn test_sequential_handshakes_exhaust_ic_cap() {
+  let pool = setup_test_db().await;
+  let agent_id = 202i64;
+  let key_id = 202_000i64;
+
+  seed_agent_budget(&pool, agent_id, 100_000_000).await; // $100 budget
+  seed_provider_key(&pool, key_id, None).await;
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+  mgr
+    .set_spending_cap(agent_id, SpendingCap::Limited(15_000_000)) // $15 cap
+    .await
+    .unwrap();
+
+  // Reserve $10 — should succeed (used: $10, cap: $15)
+  let r1 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .unwrap();
+  assert!(
+    r1.blocked_by.is_none(),
+    "LOUD FAILURE: First reservation should succeed"
+  );
+  assert_eq!(r1.granted, 10_000_000);
+
+  // Reserve $10 more — should be blocked (used: $10 + $10 = $20 > $15 cap)
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .unwrap();
+  assert_eq!(
+    r2.blocked_by,
+    Some(BlockedBy::AgentSpendingCap),
+    "LOUD FAILURE: Second reservation should be blocked by IC-key cap"
+  );
+}
+
+// ─── Test 4: Sequential handshakes exhaust IP-key cap ─────────────────────────
+
+#[tokio::test]
+async fn test_sequential_handshakes_exhaust_ip_cap() {
+  let pool = setup_test_db().await;
+  let agent_id = 203i64;
+  let key_id = 203_000i64;
+
+  seed_agent_budget(&pool, agent_id, 100_000_000).await;
+  seed_provider_key(&pool, key_id, Some(15_000_000)).await; // $15 IP-key cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+
+  // Reserve $10 — should succeed
+  let r1 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .unwrap();
+  assert!(r1.blocked_by.is_none());
+
+  // Reserve $10 more — should be blocked by IP-key cap
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .unwrap();
+  assert_eq!(
+    r2.blocked_by,
+    Some(BlockedBy::ProviderKeyCap),
+    "LOUD FAILURE: Second reservation should be blocked by IP-key cap"
+  );
+}
+
+// ─── Test 5: Budget return reverses both IC-key and IP-key spending ───────────
+
+#[tokio::test]
+async fn test_budget_return_reverses_both_caps() {
+  let pool = setup_test_db().await;
+  let agent_id = 204i64;
+  let key_id = 204_000i64;
+
+  seed_agent_budget(&pool, agent_id, 50_000_000).await;
+  seed_provider_key(&pool, key_id, Some(20_000_000)).await; // $20 IP-key cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+  let pks = ProviderKeyStorage::new(pool.clone());
+
+  mgr
+    .set_spending_cap(agent_id, SpendingCap::Limited(20_000_000)) // $20 IC-key cap
+    .await
+    .unwrap();
+
+  // Reserve $15
+  let r = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 15_000_000)
+    .await
+    .unwrap();
+  assert!(r.blocked_by.is_none());
+  assert_eq!(r.granted, 15_000_000);
+
+  // Check spending before return
+  let agent_summary = mgr.get_spending_summary(agent_id).await.unwrap();
+  assert_eq!(agent_summary.used_microdollars, 15_000_000);
+
+  let key_summary = pks.get_spending_summary(key_id).await.unwrap();
+  assert_eq!(key_summary.used_microdollars, 15_000_000);
+
+  // Return $10 of the $15
+  mgr
+    .restore_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+    .await
+    .expect("LOUD FAILURE: Should restore budget");
+
+  // Verify both decremented
+  let agent_summary = mgr.get_spending_summary(agent_id).await.unwrap();
+  assert_eq!(
+    agent_summary.used_microdollars, 5_000_000,
+    "LOUD FAILURE: Agent spending should be $5 after returning $10 of $15"
+  );
+
+  let key_summary = pks.get_spending_summary(key_id).await.unwrap();
+  assert_eq!(
+    key_summary.used_microdollars, 5_000_000,
+    "LOUD FAILURE: Provider key spending should be $5 after returning $10 of $15"
+  );
+
+  // Now reserve $15 again — should succeed (used: $5 + $15 = $20 = cap)
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 15_000_000)
+    .await
+    .unwrap();
+  assert!(
+    r2.blocked_by.is_none(),
+    "LOUD FAILURE: Should succeed after return freed up spending room"
+  );
+}
+
+// ─── Test 6: NULL cap means unlimited ─────────────────────────────────────────
+
+#[tokio::test]
+async fn test_null_cap_means_unlimited() {
+  let pool = setup_test_db().await;
+  let agent_id = 205i64;
+  let key_id = 205_000i64;
+
+  seed_agent_budget(&pool, agent_id, 1_000_000_000).await; // $1000 budget
+  seed_provider_key(&pool, key_id, None).await; // No IP-key cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+  // No IC-key cap set (default is Unlimited)
+
+  // Reserve large amounts — should succeed
+  for i in 0..5 {
+    let r = mgr
+      .reserve_budget_with_limits(agent_id, Some(key_id), 100_000_000) // $100 each
+      .await
+      .unwrap();
+    assert!(
+      r.blocked_by.is_none(),
+      "LOUD FAILURE: Reservation {i} should succeed with unlimited caps"
+    );
+  }
+}
+
+// ─── Test 7: Lease stores provider_key_id ─────────────────────────────────────
+
+#[tokio::test]
+async fn test_lease_stores_provider_key_id() {
+  let pool = setup_test_db().await;
+  let agent_id = 206i64;
+  let key_id = 206_000i64;
+
+  seed_agent_budget(&pool, agent_id, 50_000_000).await;
+  seed_provider_key(&pool, key_id, None).await;
+
+  let lm = LeaseManager::from_pool(pool.clone());
+  let lease_id = "lease_test_pkey_attr";
+
+  lm.create_lease(lease_id, agent_id, agent_id, 10_000_000, None, Some(key_id))
+    .await
+    .expect("LOUD FAILURE: Should create lease");
+
+  let lease = lm
+    .get_lease(lease_id)
+    .await
+    .expect("LOUD FAILURE: Should fetch lease")
+    .expect("LOUD FAILURE: Lease should exist");
+
+  assert_eq!(
+    lease.provider_key_id,
+    Some(key_id),
+    "LOUD FAILURE: Lease should store provider_key_id"
+  );
+}
+
+// ─── Test 8: Multiple agents share IP-key cap ─────────────────────────────────
+
+#[tokio::test]
+async fn test_multiple_agents_share_ip_key_cap() {
+  let pool = setup_test_db().await;
+  let agent_a = 207i64;
+  let agent_b = 208i64;
+  let shared_key = 207_000i64;
+
+  seed_agent_budget(&pool, agent_a, 100_000_000).await;
+  seed_agent_budget(&pool, agent_b, 100_000_000).await;
+  seed_provider_key(&pool, shared_key, Some(20_000_000)).await; // $20 shared IP cap
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+
+  // Agent A reserves $12
+  let r1 = mgr
+    .reserve_budget_with_limits(agent_a, Some(shared_key), 12_000_000)
+    .await
+    .unwrap();
+  assert!(r1.blocked_by.is_none());
+
+  // Agent B tries $12 — should be blocked (shared key used: $12 + $12 = $24 > $20)
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_b, Some(shared_key), 12_000_000)
+    .await
+    .unwrap();
+  assert_eq!(
+    r2.blocked_by,
+    Some(BlockedBy::ProviderKeyCap),
+    "LOUD FAILURE: Agent B should be blocked by shared IP-key cap"
+  );
+
+  // Agent B reserves $8 — should succeed (shared key used: $12 + $8 = $20 = cap)
+  let r3 = mgr
+    .reserve_budget_with_limits(agent_b, Some(shared_key), 8_000_000)
+    .await
+    .unwrap();
+  assert!(
+    r3.blocked_by.is_none(),
+    "LOUD FAILURE: Agent B should succeed with $8 (exactly at cap)"
+  );
+}
+
+// ─── Test 9: Agent cap isolated between agents ────────────────────────────────
+
+#[tokio::test]
+async fn test_agent_cap_isolated_between_agents() {
+  let pool = setup_test_db().await;
+  let agent_a = 209i64;
+  let agent_b = 210i64;
+  let key_a = 209_000i64;
+  let key_b = 210_000i64;
+
+  seed_agent_budget(&pool, agent_a, 100_000_000).await;
+  seed_agent_budget(&pool, agent_b, 100_000_000).await;
+  seed_provider_key(&pool, key_a, None).await;
+  seed_provider_key(&pool, key_b, None).await;
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+
+  // Set IC cap on agent A only
+  mgr
+    .set_spending_cap(agent_a, SpendingCap::Limited(5_000_000))
+    .await
+    .unwrap();
+
+  // Agent A blocked by its $5 cap
+  let r1 = mgr
+    .reserve_budget_with_limits(agent_a, Some(key_a), 10_000_000)
+    .await
+    .unwrap();
+  assert_eq!(r1.blocked_by, Some(BlockedBy::AgentSpendingCap));
+
+  // Agent B unaffected — no cap set
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_b, Some(key_b), 10_000_000)
+    .await
+    .unwrap();
+  assert!(
+    r2.blocked_by.is_none(),
+    "LOUD FAILURE: Agent B should not be affected by Agent A's cap"
+  );
+}
+
+// ─── Test 10: Concurrent handshakes respect cap ───────────────────────────────
+
+#[tokio::test]
+async fn test_concurrent_handshakes_respect_cap() {
+  let pool = setup_test_db().await;
+  let agent_id = 211i64;
+  let key_id = 211_000i64;
+
+  seed_agent_budget(&pool, agent_id, 1_000_000_000).await; // $1000 budget (plenty)
+  seed_provider_key(&pool, key_id, None).await;
+
+  let mgr = Arc::new(AgentBudgetManager::from_pool(pool.clone()));
+
+  // $50 IC-key cap, $10 per reservation → exactly 5 should succeed
+  mgr
+    .set_spending_cap(agent_id, SpendingCap::Limited(50_000_000))
+    .await
+    .unwrap();
+
+  let mut handles = Vec::new();
+  for _ in 0..10 {
+    let mgr = mgr.clone();
+    handles.push(tokio::spawn(async move {
+      mgr
+        .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000)
+        .await
+        .unwrap()
+    }));
+  }
+
+  let mut succeeded = 0;
+  let mut blocked = 0;
+  for handle in handles {
+    let result = handle.await.unwrap();
+    if result.blocked_by.is_none() {
+      succeeded += 1;
+    } else {
+      blocked += 1;
+    }
+  }
+
+  assert_eq!(
+    succeeded, 5,
+    "LOUD FAILURE: Exactly 5 reservations should succeed ($50 cap / $10 each). Got {succeeded} succeeded, {blocked} blocked"
+  );
+  assert_eq!(blocked, 5);
+}
+
+// ─── Test 11: Insufficient budget blocks before caps checked ──────────────────
+
+#[tokio::test]
+async fn test_insufficient_budget_blocks() {
+  let pool = setup_test_db().await;
+  let agent_id = 212i64;
+  let key_id = 212_000i64;
+
+  seed_agent_budget(&pool, agent_id, 5_000_000).await; // Only $5 budget
+  seed_provider_key(&pool, key_id, None).await;
+
+  let mgr = AgentBudgetManager::from_pool(pool.clone());
+  // No caps — pure budget exhaustion
+
+  let r = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 10_000_000) // Request $10
+    .await
+    .unwrap();
+
+  // Should get partial grant of $5 (the remaining budget)
+  assert!(
+    r.blocked_by.is_none(),
+    "LOUD FAILURE: Should get partial grant, not be blocked"
+  );
+  assert_eq!(
+    r.granted, 5_000_000,
+    "LOUD FAILURE: Should grant remaining $5 as partial"
+  );
+
+  // Second reservation should be blocked — budget exhausted
+  let r2 = mgr
+    .reserve_budget_with_limits(agent_id, Some(key_id), 1_000_000)
+    .await
+    .unwrap();
+  assert_eq!(
+    r2.blocked_by,
+    Some(BlockedBy::InsufficientBudget),
+    "LOUD FAILURE: Should be blocked by insufficient budget"
+  );
+}

--- a/module/iron_llm_core/src/forward.rs
+++ b/module/iron_llm_core/src/forward.rs
@@ -92,6 +92,8 @@ pub async fn forward_request(
     .as_deref()
     .unwrap_or(match target_provider {
       "anthropic" => "https://api.anthropic.com",
+      "gemini" => "https://generativelanguage.googleapis.com",
+      "xai" => "https://api.x.ai",
       _ => "https://api.openai.com",
     });
 
@@ -106,7 +108,11 @@ pub async fn forward_request(
     req_builder = req_builder
       .header("x-api-key", provider_key.api_key.expose_secret().as_str())
       .header("anthropic-version", "2023-06-01");
+  } else if target_provider == "gemini" {
+    req_builder = req_builder
+      .header("x-goog-api-key", provider_key.api_key.expose_secret().as_str());
   } else {
+    // OpenAI, xAI (OpenAI-compatible), and default
     req_builder = req_builder.header(
       header::AUTHORIZATION,
       format!("Bearer {}", provider_key.api_key.expose_secret().as_str()),

--- a/module/iron_llm_core/src/provider.rs
+++ b/module/iron_llm_core/src/provider.rs
@@ -2,7 +2,7 @@
 
 /// Strip provider prefix from path if present
 ///
-/// Recognizes `/anthropic/...` and `/openai/...` prefixes.
+/// Recognizes `/anthropic/...`, `/openai/...`, `/gemini/...`, and `/xai/...` prefixes.
 /// Returns the cleaned path and the detected provider name.
 ///
 /// # Examples
@@ -22,20 +22,20 @@
 pub fn strip_provider_prefix(path: &str) -> (String, Option<&'static str>) {
   if path.starts_with("/anthropic/") || path.starts_with("/anthropic") {
     let clean = path.strip_prefix("/anthropic").unwrap_or(path);
-    let clean = if clean.is_empty() {
-      "/".to_string()
-    } else {
-      clean.to_string()
-    };
+    let clean = if clean.is_empty() { "/".to_string() } else { clean.to_string() };
     (clean, Some("anthropic"))
   } else if path.starts_with("/openai/") || path.starts_with("/openai") {
     let clean = path.strip_prefix("/openai").unwrap_or(path);
-    let clean = if clean.is_empty() {
-      "/".to_string()
-    } else {
-      clean.to_string()
-    };
+    let clean = if clean.is_empty() { "/".to_string() } else { clean.to_string() };
     (clean, Some("openai"))
+  } else if path.starts_with("/gemini/") || path.starts_with("/gemini") {
+    let clean = path.strip_prefix("/gemini").unwrap_or(path);
+    let clean = if clean.is_empty() { "/".to_string() } else { clean.to_string() };
+    (clean, Some("gemini"))
+  } else if path.starts_with("/xai/") || path.starts_with("/xai") {
+    let clean = path.strip_prefix("/xai").unwrap_or(path);
+    let clean = if clean.is_empty() { "/".to_string() } else { clean.to_string() };
+    (clean, Some("xai"))
   } else {
     (path.to_string(), None)
   }
@@ -46,6 +46,8 @@ pub fn strip_provider_prefix(path: &str) -> (String, Option<&'static str>) {
 /// Inspects the `"model"` field of the JSON body:
 /// - Models starting with `"claude"` → `"anthropic"`
 /// - Models starting with `"gpt"`, `"o1"`, or `"o3"` → `"openai"`
+/// - Models starting with `"gemini"` → `"gemini"`
+/// - Models starting with `"grok"` → `"xai"`
 /// - Otherwise → `None`
 #[must_use]
 pub fn detect_provider_from_model(body: &[u8]) -> Option<&'static str> {
@@ -56,6 +58,12 @@ pub fn detect_provider_from_model(body: &[u8]) -> Option<&'static str> {
       }
       if model.starts_with("gpt") || model.starts_with("o1") || model.starts_with("o3") {
         return Some("openai");
+      }
+      if model.starts_with("gemini") {
+        return Some("gemini");
+      }
+      if model.starts_with("grok") {
+        return Some("xai");
       }
     }
   }

--- a/module/iron_runtime_analytics/src/provider_utils.rs
+++ b/module/iron_runtime_analytics/src/provider_utils.rs
@@ -25,6 +25,11 @@ pub enum Provider {
   OpenAI,
   /// Anthropic provider (e.g. Claude models).
   Anthropic,
+  /// Google Gemini provider.
+  Gemini,
+  /// xAI provider (e.g. Grok models).
+  #[serde(rename = "xai")]
+  XAI,
 
   /// Fallback for unknown/unsupported providers during deserialization.
   #[serde(other)]
@@ -39,6 +44,8 @@ impl Provider {
     match self {
       Self::OpenAI => "openai",
       Self::Anthropic => "anthropic",
+      Self::Gemini => "gemini",
+      Self::XAI => "xai",
       Self::Unknown => "unknown",
     }
   }
@@ -63,6 +70,8 @@ impl FromStr for Provider {
     match s {
       s if s.eq_ignore_ascii_case("openai") => Ok(Self::OpenAI),
       s if s.eq_ignore_ascii_case("anthropic") => Ok(Self::Anthropic),
+      s if s.eq_ignore_ascii_case("gemini") => Ok(Self::Gemini),
+      s if s.eq_ignore_ascii_case("xai") => Ok(Self::XAI),
       _ => Ok(Self::Unknown),
     }
   }
@@ -97,6 +106,16 @@ pub fn infer_provider(model: &str) -> Provider {
   // Check Anthropic (claude-*)
   if has_prefix_ignore_case(model, "claude-") {
     return Provider::Anthropic;
+  }
+
+  // Check Gemini (gemini-*)
+  if has_prefix_ignore_case(model, "gemini-") {
+    return Provider::Gemini;
+  }
+
+  // Check xAI (grok-*)
+  if has_prefix_ignore_case(model, "grok-") {
+    return Provider::XAI;
   }
 
   Provider::Unknown

--- a/module/iron_runtime_analytics/tests/helpers_test.rs
+++ b/module/iron_runtime_analytics/tests/helpers_test.rs
@@ -133,7 +133,19 @@ fn test_infer_provider_anthropic_case_insensitive() {
 fn test_infer_provider_unknown() {
   assert_eq!(infer_provider("llama-2-70b"), Provider::Unknown);
   assert_eq!(infer_provider("mistral-7b"), Provider::Unknown);
-  assert_eq!(infer_provider("gemini-pro"), Provider::Unknown);
   assert_eq!(infer_provider("custom-model"), Provider::Unknown);
   assert_eq!(infer_provider(""), Provider::Unknown);
+}
+
+#[test]
+fn test_infer_provider_gemini() {
+  assert_eq!(infer_provider("gemini-pro"), Provider::Gemini);
+  assert_eq!(infer_provider("gemini-1.5-pro"), Provider::Gemini);
+  assert_eq!(infer_provider("gemini-2.0-flash"), Provider::Gemini);
+}
+
+#[test]
+fn test_infer_provider_xai() {
+  assert_eq!(infer_provider("grok-2"), Provider::XAI);
+  assert_eq!(infer_provider("grok-beta"), Provider::XAI);
 }

--- a/module/iron_token_manager/migrations/026_add_spending_limits.sql
+++ b/module/iron_token_manager/migrations/026_add_spending_limits.sql
@@ -1,0 +1,19 @@
+-- Migration 026: Per-IC-key and Per-IP-key spending limits
+--
+-- Adds spending cap/used columns to agent_budgets (IC-key limits)
+-- and provider_key_id attribution to leases and analytics.
+
+-- Per-IC-key (agent) spending limit
+ALTER TABLE agent_budgets ADD COLUMN spending_cap_microdollars INTEGER;
+ALTER TABLE agent_budgets ADD COLUMN spending_used_microdollars INTEGER NOT NULL DEFAULT 0;
+
+-- Per-IP-key attribution in leases
+ALTER TABLE budget_leases ADD COLUMN provider_key_id INTEGER REFERENCES ai_provider_keys(id) ON DELETE SET NULL;
+CREATE INDEX idx_budget_leases_provider_key ON budget_leases(provider_key_id);
+
+-- Per-IP-key attribution in analytics
+ALTER TABLE analytics_events ADD COLUMN provider_key_id INTEGER;
+CREATE INDEX idx_analytics_events_provider_key ON analytics_events(provider_key_id);
+
+-- Guard table
+CREATE TABLE _migration_026_completed (id INTEGER PRIMARY KEY);

--- a/module/iron_token_manager/migrations/027_add_gemini_xai_providers.sql
+++ b/module/iron_token_manager/migrations/027_add_gemini_xai_providers.sql
@@ -1,0 +1,106 @@
+-- Migration 027: Add Gemini and xAI provider support
+--
+-- SQLite does not support ALTER TABLE to modify CHECK constraints.
+-- This migration recreates ai_provider_keys and analytics_events
+-- with updated CHECK constraints to include 'gemini' and 'xai'.
+--
+-- Full column sets include all additions from prior migrations:
+--   ai_provider_keys: spending cap columns added by migration 024
+--   analytics_events: provider_key_id column added by migration 026
+
+PRAGMA foreign_keys = OFF;
+
+-- Recreate ai_provider_keys with extended provider CHECK
+-- (includes spending_cap_microdollars, spending_used_microdollars from migration 024)
+CREATE TABLE ai_provider_keys_new
+(
+  id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider                    TEXT    NOT NULL CHECK ( provider IN ( 'openai', 'anthropic', 'gemini', 'xai' ) ),
+  encrypted_api_key           TEXT    NOT NULL,
+  encryption_nonce            TEXT    NOT NULL,
+  base_url                    TEXT    CHECK ( base_url IS NULL OR LENGTH( base_url ) <= 2000 ),
+  description                 TEXT    CHECK ( description IS NULL OR LENGTH( description ) <= 500 ),
+  is_enabled                  INTEGER NOT NULL DEFAULT 1,
+  created_at                  INTEGER NOT NULL,
+  last_used_at                INTEGER,
+  balance_cents               INTEGER,
+  balance_updated_at          INTEGER,
+  user_id                     TEXT    NOT NULL CHECK ( LENGTH( user_id ) > 0 AND LENGTH( user_id ) <= 500 ),
+  spending_cap_microdollars   INTEGER,
+  spending_used_microdollars  INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO ai_provider_keys_new
+SELECT id, provider, encrypted_api_key, encryption_nonce, base_url, description,
+       is_enabled, created_at, last_used_at, balance_cents, balance_updated_at, user_id,
+       spending_cap_microdollars, spending_used_microdollars
+FROM ai_provider_keys;
+
+DROP TABLE ai_provider_keys;
+ALTER TABLE ai_provider_keys_new RENAME TO ai_provider_keys;
+
+-- Restore indexes
+CREATE INDEX IF NOT EXISTS idx_ai_provider_keys_user_id    ON ai_provider_keys( user_id );
+CREATE INDEX IF NOT EXISTS idx_ai_provider_keys_provider   ON ai_provider_keys( provider );
+CREATE INDEX IF NOT EXISTS idx_ai_provider_keys_is_enabled ON ai_provider_keys( is_enabled );
+
+-- Recreate analytics_events with extended provider CHECK
+-- (includes provider_key_id column from migration 026)
+CREATE TABLE analytics_events_new
+(
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id        TEXT    NOT NULL,
+  timestamp_ms    INTEGER NOT NULL,
+  event_type      TEXT    NOT NULL CHECK (
+    event_type IN ('llm_request_completed', 'llm_request_failed')
+  ),
+  model           TEXT    NOT NULL,
+  provider        TEXT    NOT NULL CHECK (
+    provider IN ('openai', 'anthropic', 'gemini', 'xai', 'unknown')
+  ),
+  input_tokens    INTEGER NOT NULL DEFAULT 0,
+  output_tokens   INTEGER NOT NULL DEFAULT 0,
+  cost_micros     INTEGER NOT NULL DEFAULT 0,
+  agent_id        INTEGER,
+  provider_id     TEXT,
+  error_code      TEXT,
+  error_message   TEXT,
+  received_at     INTEGER NOT NULL,
+  provider_key_id INTEGER,
+  UNIQUE(agent_id, event_id)
+);
+
+INSERT INTO analytics_events_new
+SELECT id, event_id, timestamp_ms, event_type, model, provider,
+       input_tokens, output_tokens, cost_micros, agent_id, provider_id,
+       error_code, error_message, received_at, provider_key_id
+FROM analytics_events;
+
+DROP TABLE analytics_events;
+ALTER TABLE analytics_events_new RENAME TO analytics_events;
+
+-- Restore indexes
+CREATE INDEX IF NOT EXISTS idx_analytics_events_timestamp
+  ON analytics_events(timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_agent_id
+  ON analytics_events(agent_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_provider
+  ON analytics_events(provider);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_provider_id
+  ON analytics_events(provider_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_type
+  ON analytics_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_model
+  ON analytics_events(model);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_agent_timestamp
+  ON analytics_events(agent_id, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_provider_timestamp
+  ON analytics_events(provider, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_provider_key
+  ON analytics_events(provider_key_id);
+
+PRAGMA foreign_keys = ON;
+
+-- Guard table
+CREATE TABLE IF NOT EXISTS _migration_027_completed ( id INTEGER PRIMARY KEY );
+INSERT INTO _migration_027_completed (id) VALUES (1);

--- a/module/iron_token_manager/migrations/028_add_provider_keys_user_provider_index.sql
+++ b/module/iron_token_manager/migrations/028_add_provider_keys_user_provider_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_ai_provider_keys_user_provider
+ON ai_provider_keys(user_id, provider);

--- a/module/iron_token_manager/scripts/validate_db_schema.sh
+++ b/module/iron_token_manager/scripts/validate_db_schema.sh
@@ -51,7 +51,7 @@ log_warning() {
 }
 
 # Expected counts (update when adding migrations)
-EXPECTED_TABLE_COUNT=43   # 18 application + 25 migration guards
+EXPECTED_TABLE_COUNT=44   # 18 application + 26 migration guards
 EXPECTED_INDEX_COUNT=53
 
 # Validation state

--- a/module/iron_token_manager/spec.md
+++ b/module/iron_token_manager/spec.md
@@ -201,7 +201,8 @@ lease_mgr.create_lease(
   42,                 // agent_id
   42,                 // budget_id (1:1 with agent)
   10.0,               // budget_granted (USD)
-  None                // expires_at (optional)
+  None,               // expires_at (optional)
+  None                // provider_key_id (optional)
 ).await?;
 
 // Record usage

--- a/module/iron_token_manager/src/agent_budget.rs
+++ b/module/iron_token_manager/src/agent_budget.rs
@@ -10,6 +10,48 @@
 use sqlx::{Row, SqlitePool};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::error::TokenError;
+
+/// Explicit spending cap — no silent `None` semantics.
+///
+/// Database maps `NULL` → `Unlimited`, non-NULL → `Limited(value)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpendingCap {
+  /// No cap enforced
+  Unlimited,
+  /// Capped at this many microdollars
+  Limited(i64),
+}
+
+impl SpendingCap {
+  /// Convert from the nullable database column
+  #[must_use]
+  pub fn from_db(value: Option<i64>) -> Self {
+    match value {
+      Some(v) => Self::Limited(v),
+      None => Self::Unlimited,
+    }
+  }
+
+  /// Convert to nullable value for database storage
+  #[must_use]
+  pub fn to_db(self) -> Option<i64> {
+    match self {
+      Self::Unlimited => None,
+      Self::Limited(v) => Some(v),
+    }
+  }
+
+  /// Returns `true` if the cap would be exceeded by adding `amount` to `used`
+  #[must_use]
+  pub fn would_exceed(&self, used: i64, amount: i64) -> bool {
+    match self {
+      Self::Unlimited => false,
+      Self::Limited(cap) => used + amount > *cap,
+    }
+  }
+}
+
 /// Agent budget record
 #[derive(Debug, Clone)]
 pub struct AgentBudget {
@@ -25,6 +67,41 @@ pub struct AgentBudget {
   pub created_at: i64,
   /// Last update timestamp (milliseconds since epoch)
   pub updated_at: i64,
+  /// Per-agent spending cap
+  pub spending_cap: SpendingCap,
+  /// Cumulative spending tracked against spending cap
+  pub spending_used_microdollars: i64,
+}
+
+/// Result of a unified budget reservation attempt
+#[derive(Debug, Clone)]
+pub struct ReservationResult {
+  /// Amount granted in microdollars
+  pub granted: i64,
+  /// Agent budget remaining after reservation
+  pub agent_budget_remaining: i64,
+  /// If reservation was blocked, the reason
+  pub blocked_by: Option<BlockedBy>,
+}
+
+/// Reason a budget reservation was blocked
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlockedBy {
+  /// Agent (IC-key) spending cap exceeded
+  AgentSpendingCap,
+  /// Provider key (IP-key) spending cap exceeded
+  ProviderKeyCap,
+  /// Agent budget pool exhausted
+  InsufficientBudget,
+}
+
+/// Summary of spending for an agent
+#[derive(Debug, Clone)]
+pub struct AgentSpendingSummary {
+  /// Amount spent in microdollars
+  pub used_microdollars: i64,
+  /// Spending cap
+  pub cap: SpendingCap,
 }
 
 /// Agent budget manager for budget CRUD operations
@@ -96,7 +173,8 @@ impl AgentBudgetManager {
   /// Returns error if database query fails
   pub async fn get_budget_status(&self, agent_id: i64) -> Result<Option<AgentBudget>, sqlx::Error> {
     let row = sqlx::query(
-      "SELECT agent_id, total_allocated, total_spent, budget_remaining, created_at, updated_at
+      "SELECT agent_id, total_allocated, total_spent, budget_remaining, created_at, updated_at,
+              spending_cap_microdollars, spending_used_microdollars
       FROM agent_budgets WHERE agent_id = ?",
     )
     .bind(agent_id)
@@ -110,6 +188,8 @@ impl AgentBudgetManager {
       budget_remaining: r.get("budget_remaining"),
       created_at: r.get("created_at"),
       updated_at: r.get("updated_at"),
+      spending_cap: SpendingCap::from_db(r.get("spending_cap_microdollars")),
+      spending_used_microdollars: r.get("spending_used_microdollars"),
     }))
   }
 
@@ -441,6 +521,349 @@ impl AgentBudgetManager {
     .bind(agent_id)
     .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
+
+    Ok(())
+  }
+
+  /// Set spending cap for an agent
+  ///
+  /// # Arguments
+  ///
+  /// * `agent_id` - Agent database ID
+  /// * `cap` - Spending cap in microdollars (None = unlimited)
+  ///
+  /// # Errors
+  ///
+  /// Returns error if database update fails
+  pub async fn set_spending_cap(
+    &self,
+    agent_id: i64,
+    cap: SpendingCap,
+  ) -> core::result::Result<(), TokenError> {
+    let result =
+      sqlx::query("UPDATE agent_budgets SET spending_cap_microdollars = ? WHERE agent_id = ?")
+        .bind(cap.to_db())
+        .bind(agent_id)
+        .execute(&self.pool)
+        .await
+        .map_err(TokenError::Database)?;
+
+    if result.rows_affected() == 0 {
+      return Err(TokenError::NotFound);
+    }
+    Ok(())
+  }
+
+  /// Get spending summary for an agent (cap and used)
+  ///
+  /// # Errors
+  ///
+  /// Returns error if agent not found or database query fails
+  pub async fn get_spending_summary(
+    &self,
+    agent_id: i64,
+  ) -> core::result::Result<AgentSpendingSummary, TokenError> {
+    let row: Option<(Option<i64>, i64)> = sqlx::query_as(
+      "SELECT spending_cap_microdollars, spending_used_microdollars \
+       FROM agent_budgets WHERE agent_id = ?",
+    )
+    .bind(agent_id)
+    .fetch_optional(&self.pool)
+    .await
+    .map_err(TokenError::Database)?;
+
+    match row {
+      Some((cap, used)) => Ok(AgentSpendingSummary {
+        used_microdollars: used,
+        cap: SpendingCap::from_db(cap),
+      }),
+      None => Err(TokenError::NotFound),
+    }
+  }
+
+  /// Reset spending counter for an agent
+  ///
+  /// # Errors
+  ///
+  /// Returns error if database update fails
+  pub async fn reset_spending(
+    &self,
+    agent_id: i64,
+  ) -> core::result::Result<(), TokenError> {
+    let result = sqlx::query(
+      "UPDATE agent_budgets SET spending_used_microdollars = 0 WHERE agent_id = ?",
+    )
+    .bind(agent_id)
+    .execute(&self.pool)
+    .await
+    .map_err(TokenError::Database)?;
+
+    if result.rows_affected() == 0 {
+      return Err(TokenError::NotFound);
+    }
+    Ok(())
+  }
+
+  /// Atomically reserve budget checking both IC-key (agent) and IP-key (provider) caps.
+  ///
+  /// Single transaction:
+  /// 1. Check agent spending cap
+  /// 2. Check provider key spending cap
+  /// 3. Reserve from agent budget (partial grants supported)
+  /// 4. Increment agent `spending_used`
+  /// 5. Increment provider key `spending_used`
+  ///
+  /// # Returns
+  ///
+  /// `ReservationResult` with granted amount and optional block reason.
+  ///
+  /// # Errors
+  ///
+  /// Returns error on database failure (not for cap/budget exhaustion).
+  pub async fn reserve_budget_with_limits(
+    &self,
+    agent_id: i64,
+    provider_key_id: Option<i64>,
+    requested_amount: i64,
+  ) -> Result<ReservationResult, sqlx::Error> {
+    // Retry logic for SQLite database busy/locked/deadlocked errors
+    const MAX_RETRIES: u32 = 50;
+
+    for attempt in 0..MAX_RETRIES {
+      if attempt > 0 {
+        let backoff_ms = 2_u64.pow(attempt.min(8));
+        tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+      }
+
+      match self
+        .try_reserve_with_limits_once(agent_id, provider_key_id, requested_amount)
+        .await
+      {
+        Ok(result) => return Ok(result),
+        Err(e) => {
+          let err_msg = e.to_string().to_lowercase();
+          let is_retryable = err_msg.contains("database is locked")
+            || err_msg.contains("database is busy")
+            || err_msg.contains("deadlock");
+
+          if is_retryable && attempt < MAX_RETRIES - 1 {
+            // Retry
+          } else {
+            return Err(e);
+          }
+        }
+      }
+    }
+
+    Ok(ReservationResult {
+      granted: 0,
+      agent_budget_remaining: 0,
+      blocked_by: Some(BlockedBy::InsufficientBudget),
+    })
+  }
+
+  /// Single attempt to reserve budget with limits (internal helper)
+  async fn try_reserve_with_limits_once(
+    &self,
+    agent_id: i64,
+    provider_key_id: Option<i64>,
+    requested_amount: i64,
+  ) -> Result<ReservationResult, sqlx::Error> {
+    #[allow(clippy::cast_possible_truncation)]
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .expect("LOUD FAILURE: Time went backwards")
+      .as_millis() as i64;
+
+    let mut tx = self.pool.begin().await?;
+
+    // 1. Check agent spending cap
+    let agent_row = sqlx::query(
+      "SELECT spending_cap_microdollars, spending_used_microdollars, total_spent, budget_remaining \
+       FROM agent_budgets WHERE agent_id = ?",
+    )
+    .bind(agent_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(agent_row) = agent_row else {
+      tx.rollback().await?;
+      return Ok(ReservationResult {
+        granted: 0,
+        agent_budget_remaining: 0,
+        blocked_by: Some(BlockedBy::InsufficientBudget),
+      });
+    };
+
+    let agent_cap = SpendingCap::from_db(agent_row.get("spending_cap_microdollars"));
+    let agent_used: i64 = agent_row.get("spending_used_microdollars");
+    let budget_remaining: i64 = agent_row.get("budget_remaining");
+
+    // Check IC-key (agent) spending cap
+    if agent_cap.would_exceed(agent_used, requested_amount) {
+      tx.rollback().await?;
+      return Ok(ReservationResult {
+        granted: 0,
+        agent_budget_remaining: budget_remaining,
+        blocked_by: Some(BlockedBy::AgentSpendingCap),
+      });
+    }
+
+    // 2. Check IP-key (provider key) spending cap
+    if let Some(pkey_id) = provider_key_id {
+      let pkey_row = sqlx::query(
+        "SELECT spending_cap_microdollars, spending_used_microdollars \
+         FROM ai_provider_keys WHERE id = ?",
+      )
+      .bind(pkey_id)
+      .fetch_optional(&mut *tx)
+      .await?;
+
+      if let Some(pkey_row) = pkey_row {
+        let pkey_cap = SpendingCap::from_db(pkey_row.get("spending_cap_microdollars"));
+        let pkey_used: i64 = pkey_row.get("spending_used_microdollars");
+
+        if pkey_cap.would_exceed(pkey_used, requested_amount) {
+          tx.rollback().await?;
+          return Ok(ReservationResult {
+            granted: 0,
+            agent_budget_remaining: budget_remaining,
+            blocked_by: Some(BlockedBy::ProviderKeyCap),
+          });
+        }
+      }
+    }
+
+    // 3. Reserve from agent budget (partial grants supported)
+    let spent_before: i64 = agent_row.get("total_spent");
+
+    let result = sqlx::query(
+      "UPDATE agent_budgets
+      SET total_spent = total_spent +
+        CASE WHEN budget_remaining < ? THEN budget_remaining ELSE ? END,
+          budget_remaining = budget_remaining -
+        CASE WHEN budget_remaining < ? THEN budget_remaining ELSE ? END,
+          updated_at = ?
+      WHERE agent_id = ? AND budget_remaining > 0",
+    )
+    .bind(requested_amount)
+    .bind(requested_amount)
+    .bind(requested_amount)
+    .bind(requested_amount)
+    .bind(now)
+    .bind(agent_id)
+    .execute(&mut *tx)
+    .await?;
+
+    let granted = if result.rows_affected() == 1 {
+      let row = sqlx::query("SELECT total_spent, budget_remaining FROM agent_budgets WHERE agent_id = ?")
+        .bind(agent_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+      let spent_after: i64 = row.get("total_spent");
+      spent_after - spent_before
+    } else {
+      tx.rollback().await?;
+      return Ok(ReservationResult {
+        granted: 0,
+        agent_budget_remaining: budget_remaining,
+        blocked_by: Some(BlockedBy::InsufficientBudget),
+      });
+    };
+
+    // 4. Increment agent spending_used
+    sqlx::query(
+      "UPDATE agent_budgets SET spending_used_microdollars = spending_used_microdollars + ? WHERE agent_id = ?",
+    )
+    .bind(granted)
+    .bind(agent_id)
+    .execute(&mut *tx)
+    .await?;
+
+    // 5. Increment provider key spending_used
+    if let Some(pkey_id) = provider_key_id {
+      sqlx::query(
+        "UPDATE ai_provider_keys SET spending_used_microdollars = spending_used_microdollars + ? WHERE id = ?",
+      )
+      .bind(granted)
+      .bind(pkey_id)
+      .execute(&mut *tx)
+      .await?;
+    }
+
+    // Get final budget_remaining
+    let final_row = sqlx::query("SELECT budget_remaining FROM agent_budgets WHERE agent_id = ?")
+      .bind(agent_id)
+      .fetch_one(&mut *tx)
+      .await?;
+    let final_remaining: i64 = final_row.get("budget_remaining");
+
+    tx.commit().await?;
+
+    Ok(ReservationResult {
+      granted,
+      agent_budget_remaining: final_remaining,
+      blocked_by: None,
+    })
+  }
+
+  /// Atomically restore budget to both agent and provider key.
+  ///
+  /// Single transaction reverses reservation:
+  /// 1. Restore agent budget (`total_spent`, `budget_remaining`, `spending_used`)
+  /// 2. Restore provider key `spending_used` (if `provider_key_id` present)
+  ///
+  /// # Errors
+  ///
+  /// Returns error on database failure.
+  ///
+  /// # Panics
+  ///
+  /// Panics if system time is before UNIX epoch (should never happen on modern systems)
+  pub async fn restore_budget_with_limits(
+    &self,
+    agent_id: i64,
+    provider_key_id: Option<i64>,
+    returned_amount: i64,
+  ) -> Result<(), sqlx::Error> {
+    #[allow(clippy::cast_possible_truncation)]
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .expect("LOUD FAILURE: Time went backwards")
+      .as_millis() as i64;
+
+    let mut tx = self.pool.begin().await?;
+
+    // Restore agent budget + decrement spending_used
+    sqlx::query(
+      "UPDATE agent_budgets
+      SET total_spent = total_spent - ?,
+          budget_remaining = budget_remaining + ?,
+          spending_used_microdollars = spending_used_microdollars - ?,
+          updated_at = ?
+      WHERE agent_id = ?",
+    )
+    .bind(returned_amount)
+    .bind(returned_amount)
+    .bind(returned_amount)
+    .bind(now)
+    .bind(agent_id)
+    .execute(&mut *tx)
+    .await?;
+
+    // Restore provider key spending_used
+    if let Some(pkey_id) = provider_key_id {
+      sqlx::query(
+        "UPDATE ai_provider_keys SET spending_used_microdollars = spending_used_microdollars - ? WHERE id = ?",
+      )
+      .bind(returned_amount)
+      .bind(pkey_id)
+      .execute(&mut *tx)
+      .await?;
+    }
 
     tx.commit().await?;
 

--- a/module/iron_token_manager/src/lease_manager.rs
+++ b/module/iron_token_manager/src/lease_manager.rs
@@ -37,6 +37,8 @@ pub struct BudgetLease {
   pub created_at: i64,
   /// Expiration timestamp (milliseconds since epoch, None for no expiration)
   pub expires_at: Option<i64>,
+  /// Provider key ID used for this lease (for spending attribution)
+  pub provider_key_id: Option<i64>,
 }
 
 /// Lease manager for budget lease CRUD operations
@@ -80,6 +82,7 @@ impl LeaseManager {
     budget_id: i64,
     budget_granted: i64,
     expires_at: Option<i64>,
+    provider_key_id: Option<i64>,
   ) -> Result<(), sqlx::Error> {
     #[allow(clippy::cast_possible_truncation)]
     let now = SystemTime::now()
@@ -89,8 +92,8 @@ impl LeaseManager {
 
     sqlx::query(
       "INSERT INTO budget_leases
-      (id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at)
-      VALUES (?, ?, ?, ?, 0, 'active', ?, ?)",
+      (id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at, provider_key_id)
+      VALUES (?, ?, ?, ?, 0, 'active', ?, ?, ?)",
     )
     .bind(lease_id)
     .bind(agent_id)
@@ -98,6 +101,7 @@ impl LeaseManager {
     .bind(budget_granted)
     .bind(now)
     .bind(expires_at)
+    .bind(provider_key_id)
     .execute(&self.pool)
     .await?;
 
@@ -115,7 +119,7 @@ impl LeaseManager {
   /// Returns error if database query fails
   pub async fn get_lease(&self, lease_id: &str) -> Result<Option<BudgetLease>, sqlx::Error> {
     let row = sqlx::query(
-      "SELECT id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at
+      "SELECT id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at, provider_key_id
       FROM budget_leases WHERE id = ?"
     )
     .bind( lease_id )
@@ -131,6 +135,7 @@ impl LeaseManager {
       lease_status: r.get("lease_status"),
       created_at: r.get("created_at"),
       expires_at: r.get("expires_at"),
+      provider_key_id: r.get("provider_key_id"),
     }))
   }
 
@@ -235,7 +240,7 @@ impl LeaseManager {
   /// Returns error if database query fails
   pub async fn get_agent_leases(&self, agent_id: i64) -> Result<Vec<BudgetLease>, sqlx::Error> {
     let rows = sqlx::query(
-      "SELECT id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at
+      "SELECT id, agent_id, budget_id, budget_granted, budget_spent, lease_status, created_at, expires_at, provider_key_id
       FROM budget_leases WHERE agent_id = ? AND lease_status = 'active'"
     )
     .bind( agent_id )
@@ -254,6 +259,7 @@ impl LeaseManager {
           lease_status: r.get("lease_status"),
           created_at: r.get("created_at"),
           expires_at: r.get("expires_at"),
+          provider_key_id: r.get("provider_key_id"),
         })
         .collect(),
     )

--- a/module/iron_token_manager/src/lib.rs
+++ b/module/iron_token_manager/src/lib.rs
@@ -97,5 +97,6 @@ pub mod user_service;
 // Re-exports for convenient access
 pub use config::Config;
 pub use migrations::apply_all_migrations;
+pub use agent_budget::{BlockedBy, ReservationResult, SpendingCap};
 pub use provider_key_storage::{ProviderKeyStorage, ProviderType, SpendingSummary};
 pub use seed::{seed_all, seed_users, wipe_database};

--- a/module/iron_token_manager/src/migrations.rs
+++ b/module/iron_token_manager/src/migrations.rs
@@ -80,6 +80,7 @@ static MIGRATIONS: &[(&str, &str)] = &[
   migration!("023_seed_agent1_ic_token"),
   migration!("024_add_ip_key_spending_cap"),
   migration!("025_rename_roles"),
+  migration!("026_add_spending_limits"),
 ];
 
 /// Applies all migrations to the database pool.

--- a/module/iron_token_manager/src/migrations.rs
+++ b/module/iron_token_manager/src/migrations.rs
@@ -81,6 +81,7 @@ static MIGRATIONS: &[(&str, &str)] = &[
   migration!("024_add_ip_key_spending_cap"),
   migration!("025_rename_roles"),
   migration!("026_add_spending_limits"),
+  migration!("027_add_gemini_xai_providers"),
 ];
 
 /// Applies all migrations to the database pool.

--- a/module/iron_token_manager/src/provider_key_storage.rs
+++ b/module/iron_token_manager/src/provider_key_storage.rs
@@ -1,6 +1,6 @@
 //! AI Provider Key storage layer
 //!
-//! Manages encrypted storage of AI provider API keys (`OpenAI`, `Anthropic`).
+//! Manages encrypted storage of AI provider API keys (`OpenAI`, `Anthropic`, `Gemini`, `XAI`).
 
 use core::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -15,6 +15,10 @@ pub enum ProviderType {
   OpenAI,
   /// `Anthropic` provider
   Anthropic,
+  /// Google Gemini provider
+  Gemini,
+  /// xAI provider
+  XAI,
 }
 
 impl ProviderType {
@@ -24,6 +28,8 @@ impl ProviderType {
     match self {
       Self::OpenAI => "openai",
       Self::Anthropic => "anthropic",
+      Self::Gemini => "gemini",
+      Self::XAI => "xai",
     }
   }
 
@@ -35,6 +41,8 @@ impl ProviderType {
     match s {
       "openai" => Some(Self::OpenAI),
       "anthropic" => Some(Self::Anthropic),
+      "gemini" => Some(Self::Gemini),
+      "xai" => Some(Self::XAI),
       _ => None,
     }
   }

--- a/module/iron_token_manager/tests/database_initialization.rs
+++ b/module/iron_token_manager/tests/database_initialization.rs
@@ -175,8 +175,8 @@ async fn test_production_schema_matches_test_schema() {
       .expect("LOUD FAILURE: Failed to count indexes");
 
   assert_eq!(
-    index_count, 53,
-    "Should have 53 indexes across all migrations"
+    index_count, 55,
+    "Should have 55 indexes across all migrations"
   );
 }
 
@@ -219,8 +219,8 @@ async fn test_all_migrations_have_guards() {
   let pool = db.pool().clone();
   core::mem::forget(db);
 
-  // Verify guard tables exist for all migrations (001-025)
-  let guard_tables: Vec<String> = (1..=25)
+  // Verify guard tables exist for all migrations (001-026)
+  let guard_tables: Vec<String> = (1..=26)
     .map(|n| format!("_migration_{n:03}_completed"))
     .collect();
 

--- a/module/iron_token_manager/tests/database_schema.rs
+++ b/module/iron_token_manager/tests/database_schema.rs
@@ -436,9 +436,9 @@ async fn test_all_indexes_created() {
   // Migration 019: Rebuilds budget_leases, agent_budgets, usage_limits (now recreates idx_agent_budgets_updated)
   // Migration 020: 1 index (idx_agents_provider_key_id)
   // Migration 022: 1 index (idx_agents_ic_token_hash)
-  // Total: 15 + 2 + 5 + 4 + 4 + 2 + 3 + 1 + 2 + 8 + 1 + 0 + 1 + 1 + 0 + 1 + 1 = 51
+  // Migration 026: 2 indexes (idx_budget_leases_provider_key, idx_analytics_events_provider_key)
   assert_eq!(
-    index_count, 53,
-    "Expected 53 indexes to be created across all migrations"
+    index_count, 55,
+    "Expected 55 indexes to be created across all migrations"
   );
 }


### PR DESCRIPTION
## Summary

Large feature branch that introduces several major capabilities to the Iron SDK:

- **`iron_llm_core` crate** — New shared LLM routing library extracted from `iron_runtime`, providing common provider detection, cost calculation, request/response translation, and error handling
- **`iron_server_proxy` crate** — Server-side LLM proxy binary with rate limiting, master key auth, and forwarding to upstream providers
- **Multi-provider support** — Adds Gemini and xAI alongside existing OpenAI/Anthropic providers, with full migration, validation, and API handling
- **Spending limits** — Per-key (IP-key) and per-agent (IC-key) spending caps with enforcement in analytics/usage paths
- **Analytics enhancements** — Period-over-period comparison (`compare=true`), `provider_key_id` tracking, and extended query capabilities
- **RBAC overhaul** — Renamed roles, granular permissions, and wired enforcement across control API routes
- **Security hardening** — Constant-time token auth, parameterized migration SQL, sanitized provider errors, zeroized key material, auth rate limiting
- **Deployment infrastructure** — systemd services, nginx config, env templates, setup script, and operational runbook
- **Admin seeding** — `init_admin` CLI binary for initial account and credentials bootstrapping

## Changes

- **148 files changed** (+9,766 / -3,192 lines)
- 7 new database migrations (024–028 + index)
- New crates: `iron_llm_core`, `iron_server_proxy`
- Extensive test coverage: providers API, multi-key, spending limits, e2e smoke, rate limiter, RBAC, translator, cost calculation

## Test plan

- [ ] Verify `iron_llm_core` unit tests pass (cost, provider, translator, error)
- [ ] Verify `iron_server_proxy` e2e smoke and rate limiter tests pass
- [ ] Run providers API and multi-key integration tests
- [ ] Run spending limits tests (concurrency, edge cases, null/unlimited caps)
- [ ] Verify analytics period-over-period comparison with `compare=true`
- [ ] Confirm database migrations apply cleanly (024–028)
- [ ] Test RBAC enforcement across control API endpoints
- [ ] Validate deployment artifacts (systemd, nginx, env templates)
